### PR TITLE
List all templates (MVP)

### DIFF
--- a/api/src/routes/template.ts
+++ b/api/src/routes/template.ts
@@ -1,6 +1,4 @@
 import express, { Request, Response, Router } from "express";
-import { body } from "express-validator";
-import { validateRequest } from "../middlewares/validate-request";
 import { TemplateService } from "../services/template";
 import { genHash } from "../utils/gen-hash";
 import { mixpanelTrack } from "../utils/mixpanel";
@@ -13,18 +11,12 @@ function templateRouter(
   const router = express.Router();
 
   router.get("/templates", async (req: Request, res: Response) => {
-    const name = req.query.name as string;
+    const name = req.query.name as string | undefined;
 
     if (!name) {
-      mixpanelTrack("get_template_by_name", {
-        name,
-        status: 400,
-      });
+      const allTemplates = await templateService.getAllTemplates();
 
-      res.status(400);
-      return res.send(
-        `GET /templates-- Required query parameter "name" not provided.`
-      );
+      return res.send(allTemplates)
     }
 
     let templateId: string = "";

--- a/api/src/services/template.ts
+++ b/api/src/services/template.ts
@@ -26,22 +26,29 @@ class TemplateService {
     return newTemplate;
   }
 
-  async getTemplate(templateId: string) {
-    let foundTemplate: Template;
+  async getAllTemplates() {
+    const foundTemplates = await Template.query();
 
-    foundTemplate = (
+    return foundTemplates.map(template => this.deserializeTemplateJson(template))
+  }
+
+  async getTemplate(templateId: string) {
+    const foundTemplate = (
       await Template.query().where({
         id: templateId,
       })
     )[0];
 
-    let foundTemplateJson = foundTemplate?.json_string || null;
+   if (foundTemplate) {
+     return this.deserializeTemplateJson(foundTemplate)
+   } else {
+     return null;
+   }
+  }
 
-    if (typeof foundTemplateJson === "string") {
-      foundTemplateJson = JSON.parse(foundTemplateJson);
-    }
-
-    return foundTemplateJson;
+  private deserializeTemplateJson(template: Template) {
+    let foundTemplateJson = template.json_string;
+    return JSON.parse(foundTemplateJson);
   }
 
   async getTemplateByCadenceASTHash(cadenceASTHash: string, network: string) {


### PR DESCRIPTION
Modify an existing `/v1/templates` endpoint to retrieve all templates instead of throwing an error, if `name` query parameter isn't provided.

This is technically a breaking change, so if we'd wanna merge this to the main repo, we'd need to move this logic to v2 endpoints added here: https://github.com/onflow/flow-interaction-template-service/pull/28

This isn't an ideal solution for a few reasons:
- this same endpoint now returns either a list of templates, a single template, or an empty value (if using the `name` query param)
  - it could be a more flexible approach to let it only return a list of resources. In that way, this could be a general purpouse search endpoint, possibly supporting multiple query params and always returning a list of search results.
- always returning all snapshots in the database, may not be a scalable solution long term
  - it should be fine for now, as there are only a couple hundred templates available (when counting the seeded ones only)