### PR TITLE
Add migrated Blocto transaction for testnet (temporary)

### DIFF
--- a/templates/Blocto/afl-buy-pack.json
+++ b/templates/Blocto/afl-buy-pack.json
@@ -1,0 +1,79 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "9e05a9cde9138c4aef16a41b86f6e3ce0a26935acc21bc1008397e8bdfad78e9",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "AFL Buy pack"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase AFL pack(s) for {price} USDC"
+                }
+            }
+        },
+        "cadence": "import AFLAdmin from 0xAFL_ADDRESS\nimport AFLPack from 0xAFL_ADDRESS\nimport FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FiatToken from 0xFIAT_TOKEN_ADDRESS\n\ntransaction(templateIds: [UInt64], packTemplateId: UInt64, price:UFix64, receiptAddress: Address) {\n  let adminRef: &AFLPack.Pack\n  let temporaryVault : @FungibleToken.Vault\n  prepare(adminAccount: AuthAccount, tokenRecipientAccount: AuthAccount){\n      self.adminRef = adminAccount.borrow<&AFLPack.Pack>(from: AFLPack.PackStoragePath)\n          ??panic(\"could not borrow admin reference\")\n      let vaultRef = tokenRecipientAccount.borrow<&FiatToken.Vault>(from: FiatToken.VaultStoragePath)\n              ??panic(\"could not borrow vault\")\n      self.temporaryVault <- vaultRef.withdraw(amount: price)\n  }\n  execute{\n      self.adminRef.buyPack(templateIds: templateIds, packTemplateId: packTemplateId, receiptAddress: receiptAddress, price: price, flowPayment: <- self.temporaryVault)\n  }\n}",
+        "dependencies": {
+            "0xAFL_ADDRESS": {
+                "AFLPack": {
+                    "testnet": {
+                        "address": "0xb39a42479c1c2c77",
+                        "contract": "AFLPack",
+                        "fq_address": "A.0xb39a42479c1c2c77.AFLPack",
+                        "pin": "9f480a76a29283e85debad372cb6d3c77e16dd4cdf4509739db034d571e842db",
+                        "pin_block_height": 139076020
+                    }
+                }
+            },
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076031
+                    }
+                }
+            },
+            "0xFIAT_TOKEN_ADDRESS": {
+                "FiatToken": {
+                    "testnet": {
+                        "address": "0xa983fecbed621163",
+                        "contract": "FiatToken",
+                        "fq_address": "A.0xa983fecbed621163.FiatToken",
+                        "pin": "ec7be5050256b8b9ab2a6f5550a42b6a64627fa7e684a88de5dd767864f0471a",
+                        "pin_block_height": 139076049
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "templateIds": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "packTemplateId": {
+                "index": 1,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "price": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "receiptAddress": {
+                "index": 3,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/biscuitsngroovy-borrow-money-by-nft.json
+++ b/templates/Blocto/biscuitsngroovy-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "5d94a36874e81e48ca6315e65d94153b29bc400b566580563dc7191170995640",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BiscuitsNGroovy Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/BnGNFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138885717
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138885759
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138885823
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138885859
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/biscuitsngroovy-cancel-borrow-money.json
+++ b/templates/Blocto/biscuitsngroovy-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "6a1d677eaca3f3a0f60c68e765c9b07d105170e371ba7ee0a80114afa96ffc25",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BiscuitsNGroovy Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/BnGNFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138885812
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138885880
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/biscuitsngroovy-force-redeem.json
+++ b/templates/Blocto/biscuitsngroovy-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "74df7edc0d5a7f8ddaa3032a423b20d375cc4aa935948429dd841d28e7a4f848",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BiscuitsNGroovy Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/BnGNFTCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138885859
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138885930
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/biscuitsngroovy-lend-money.json
+++ b/templates/Blocto/biscuitsngroovy-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "f4321a7a20d145a2b2e29ccd2b2b5553a7c9b83cc09e46d7d43ce7a3073f594a",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BiscuitsNGroovy Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138885919
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138885966
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/biscuitsngroovy-repay.json
+++ b/templates/Blocto/biscuitsngroovy-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "e26041ee88d8d432b695f96748e54744371cbaa9281d836df0491c17f794fad9",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BiscuitsNGroovy Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/BnGNFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138885880
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138885953
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138885972
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-blocto-token-for-exact-flow-token.json
+++ b/templates/Blocto/bloctoswap-swap-blocto-token-for-exact-flow-token.json
@@ -1,0 +1,93 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "32c879b5ce7b34df42ea48463f522abeb437d536b9e147bd32daab9135ccf364",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap blocto token for exact flow token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {maxAmountIn} BLT for at least {amountOut} FLOW",
+                    "zh-CN": "将最多 {maxAmountIn} BLT 兑换成 {amountOut} FLOW",
+                    "zh-TW": "將最多 {maxAmountIn} BLT 兌換成 {amountOut} FLOW"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport BltUsdtSwapPair from 0xBLT_USDT_SWAP_PAIR_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\n\ntransaction(maxAmountIn: UFix64, amountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    let amount0 = FlowSwapPair.quoteSwapToken2ForExactToken1(amount: amountOut) / (1.0 - FlowSwapPair.getFeePercentage())\nlet amountIn = BltUsdtSwapPair.quoteSwapToken1ForExactToken2(amount: amount0) / (1.0 - BltUsdtSwapPair.getFeePercentage())\n    assert(amountIn <= maxAmountIn, message: \"Input amount too large\")\n\n    let bloctoTokenVault = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- bloctoTokenVault.withdraw(amount: amountIn) as! @BloctoToken.Vault\n    let token1Vault <- BltUsdtSwapPair.swapToken1ForToken2(from: <- token0Vault)\nlet token2Vault <- FlowSwapPair.swapToken2ForToken1(from: <- token1Vault)\n\n      if signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) == nil {\n    signer.save(<-FlowToken.createEmptyVault(), to: /storage/flowTokenVault)\n    signer.link<&FlowToken.Vault{FungibleToken.Receiver}>(\n      /public/flowTokenReceiver,\n      target: /storage/flowTokenVault\n    )\n    signer.link<&FlowToken.Vault{FungibleToken.Balance}>(\n      /public/flowTokenBalance,\n      target: /storage/flowTokenVault\n    )\n  }\n    let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    \n\n    flowTokenVault.deposit(from: <- token2Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075894
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075907
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075917
+                    }
+                }
+            },
+            "0xBLT_USDT_SWAP_PAIR_ADDRESS": {
+                "BltUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0xc59604d4e65f14b3",
+                        "contract": "BltUsdtSwapPair",
+                        "fq_address": "A.0xc59604d4e65f14b3.BltUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139075969
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076007
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "maxAmountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "amountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-blocto-token-for-exact-fusd.json
+++ b/templates/Blocto/bloctoswap-swap-blocto-token-for-exact-fusd.json
@@ -1,0 +1,93 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "833cb399f8e2ef7346d1f9c2180b1a40b58ac3f6b8f80edae8ecb091647e5867",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap blocto token for exact fusd"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {maxAmountIn} BLT for at least {amountOut} FUSD",
+                    "zh-CN": "将最多 {maxAmountIn} BLT 兑换成 {amountOut} FUSD",
+                    "zh-TW": "將最多 {maxAmountIn} BLT 兌換成 {amountOut} FUSD"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport BltUsdtSwapPair from 0xBLT_USDT_SWAP_PAIR_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\n\ntransaction(maxAmountIn: UFix64, amountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    let amount0 = FusdUsdtSwapPair.quoteSwapToken2ForExactToken1(amount: amountOut) / (1.0 - FusdUsdtSwapPair.getFeePercentage())\nlet amountIn = BltUsdtSwapPair.quoteSwapToken1ForExactToken2(amount: amount0) / (1.0 - BltUsdtSwapPair.getFeePercentage())\n    assert(amountIn <= maxAmountIn, message: \"Input amount too large\")\n\n    let bloctoTokenVault = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- bloctoTokenVault.withdraw(amount: amountIn) as! @BloctoToken.Vault\n    let token1Vault <- BltUsdtSwapPair.swapToken1ForToken2(from: <- token0Vault)\nlet token2Vault <- FusdUsdtSwapPair.swapToken2ForToken1(from: <- token1Vault)\n\n      if signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) == nil {\n    signer.save(<-FUSD.createEmptyVault(), to: /storage/fusdVault)\n    signer.link<&FUSD.Vault{FungibleToken.Receiver}>(\n      /public/fusdReceiver,\n      target: /storage/fusdVault\n    )\n    signer.link<&FUSD.Vault{FungibleToken.Balance}>(\n      /public/fusdBalance,\n      target: /storage/fusdVault\n    )\n  }\n    let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    \n\n    fusdVault.deposit(from: <- token2Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075795
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075828
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075859
+                    }
+                }
+            },
+            "0xBLT_USDT_SWAP_PAIR_ADDRESS": {
+                "BltUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0xc59604d4e65f14b3",
+                        "contract": "BltUsdtSwapPair",
+                        "fq_address": "A.0xc59604d4e65f14b3.BltUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139075902
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139075933
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "maxAmountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "amountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-blocto-token-for-exact-usdt.json
+++ b/templates/Blocto/bloctoswap-swap-blocto-token-for-exact-usdt.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "8492c19aea851affeb8d664bdb531214bcd08bf242d4460d37ba8f7ad61e6c69",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap blocto token for exact usdt"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {maxAmountIn} BLT for at least {amountOut} tUSDT",
+                    "zh-CN": "将最多 {maxAmountIn} BLT 兑换成 {amountOut} tUSDT",
+                    "zh-TW": "將最多 {maxAmountIn} BLT 兌換成 {amountOut} tUSDT"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\nimport BltUsdtSwapPair from 0xBLT_USDT_SWAP_PAIR_ADDRESS\n\ntransaction(maxAmountIn: UFix64, amountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    let amountIn = BltUsdtSwapPair.quoteSwapToken1ForExactToken2(amount: amountOut) / (1.0 - BltUsdtSwapPair.getFeePercentage())\n    assert(amountIn <= maxAmountIn, message: \"Input amount too large\")\n\n    let bloctoTokenVault = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- bloctoTokenVault.withdraw(amount: amountIn) as! @BloctoToken.Vault\n    let token1Vault <- BltUsdtSwapPair.swapToken1ForToken2(from: <- token0Vault)\n\n      if signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) == nil {\n    signer.save(<-TeleportedTetherToken.createEmptyVault(), to: TeleportedTetherToken.TokenStoragePath)\n    signer.link<&TeleportedTetherToken.Vault{FungibleToken.Receiver}>(\n      TeleportedTetherToken.TokenPublicReceiverPath,\n      target: TeleportedTetherToken.TokenStoragePath\n    )\n    signer.link<&TeleportedTetherToken.Vault{FungibleToken.Balance}>(\n      TeleportedTetherToken.TokenPublicBalancePath,\n      target: TeleportedTetherToken.TokenStoragePath\n    )\n  }\n    let teleportedTetherTokenVault = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    \n\n    teleportedTetherTokenVault.deposit(from: <- token1Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075853
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075881
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075899
+                    }
+                }
+            },
+            "0xBLT_USDT_SWAP_PAIR_ADDRESS": {
+                "BltUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0xc59604d4e65f14b3",
+                        "contract": "BltUsdtSwapPair",
+                        "fq_address": "A.0xc59604d4e65f14b3.BltUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139075927
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "maxAmountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "amountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-exact-blocto-token-for-flow.json
+++ b/templates/Blocto/bloctoswap-swap-exact-blocto-token-for-flow.json
@@ -1,0 +1,93 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "5f137a15e071cee7f7adbe9b89a8aaefefde7fecd0b38573f793dc45ecf3a7b3",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap exact blocto token for flow"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {amountIn} BLT for at least {minAmountOut} FLOW",
+                    "zh-CN": "将 {amountIn} BLT 兑换成至少 {minAmountOut} FLOW",
+                    "zh-TW": "將 {amountIn} BLT 兌換成至少 {minAmountOut} FLOW"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport BltUsdtSwapPair from 0xBLT_USDT_SWAP_PAIR_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let bloctoTokenVault = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- bloctoTokenVault.withdraw(amount: amountIn) as! @BloctoToken.Vault\n    let token1Vault <- BltUsdtSwapPair.swapToken1ForToken2(from: <- token0Vault)\nlet token2Vault <- FlowSwapPair.swapToken2ForToken1(from: <- token1Vault)\n\n      if signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) == nil {\n    signer.save(<-FlowToken.createEmptyVault(), to: /storage/flowTokenVault)\n    signer.link<&FlowToken.Vault{FungibleToken.Receiver}>(\n      /public/flowTokenReceiver,\n      target: /storage/flowTokenVault\n    )\n    signer.link<&FlowToken.Vault{FungibleToken.Balance}>(\n      /public/flowTokenBalance,\n      target: /storage/flowTokenVault\n    )\n  }\n    let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token2Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    flowTokenVault.deposit(from: <- token2Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075894
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075907
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075920
+                    }
+                }
+            },
+            "0xBLT_USDT_SWAP_PAIR_ADDRESS": {
+                "BltUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0xc59604d4e65f14b3",
+                        "contract": "BltUsdtSwapPair",
+                        "fq_address": "A.0xc59604d4e65f14b3.BltUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139075964
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076001
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-exact-blocto-token-for-fusd.json
+++ b/templates/Blocto/bloctoswap-swap-exact-blocto-token-for-fusd.json
@@ -1,0 +1,93 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "92bc4ddcc31a397428a5aecb4ab9f0c776f2b497bf8293c3d422ed55456ed250",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap exact blocto token for fusd"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {amountIn} BLT for at least {minAmountOut} FUSD",
+                    "zh-CN": "将 {amountIn} BLT 兑换成至少 {minAmountOut} FUSD",
+                    "zh-TW": "將 {amountIn} BLT 兌換成至少 {minAmountOut} FUSD"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport BltUsdtSwapPair from 0xBLT_USDT_SWAP_PAIR_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let bloctoTokenVault = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- bloctoTokenVault.withdraw(amount: amountIn) as! @BloctoToken.Vault\n    let token1Vault <- BltUsdtSwapPair.swapToken1ForToken2(from: <- token0Vault)\nlet token2Vault <- FusdUsdtSwapPair.swapToken2ForToken1(from: <- token1Vault)\n\n      if signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) == nil {\n    signer.save(<-FUSD.createEmptyVault(), to: /storage/fusdVault)\n    signer.link<&FUSD.Vault{FungibleToken.Receiver}>(\n      /public/fusdReceiver,\n      target: /storage/fusdVault\n    )\n    signer.link<&FUSD.Vault{FungibleToken.Balance}>(\n      /public/fusdBalance,\n      target: /storage/fusdVault\n    )\n  }\n    let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token2Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    fusdVault.deposit(from: <- token2Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075947
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075964
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075993
+                    }
+                }
+            },
+            "0xBLT_USDT_SWAP_PAIR_ADDRESS": {
+                "BltUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0xc59604d4e65f14b3",
+                        "contract": "BltUsdtSwapPair",
+                        "fq_address": "A.0xc59604d4e65f14b3.BltUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076020
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076050
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-exact-blocto-token-for-usdt.json
+++ b/templates/Blocto/bloctoswap-swap-exact-blocto-token-for-usdt.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "634ee54b2aee0a5ae13c8e791eb5d2b84e44e2d2ab1cc0f58ab1b6fb2bdb441b",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap exact blocto token for usdt"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {amountIn} BLT for at least {minAmountOut} tUSDT",
+                    "zh-CN": "将 {amountIn} BLT 兑换成至少 {minAmountOut} tUSDT",
+                    "zh-TW": "將 {amountIn} BLT 兌換成至少 {minAmountOut} tUSDT"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\nimport BltUsdtSwapPair from 0xBLT_USDT_SWAP_PAIR_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let bloctoTokenVault = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- bloctoTokenVault.withdraw(amount: amountIn) as! @BloctoToken.Vault\n    let token1Vault <- BltUsdtSwapPair.swapToken1ForToken2(from: <- token0Vault)\n\n      if signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) == nil {\n    signer.save(<-TeleportedTetherToken.createEmptyVault(), to: TeleportedTetherToken.TokenStoragePath)\n    signer.link<&TeleportedTetherToken.Vault{FungibleToken.Receiver}>(\n      TeleportedTetherToken.TokenPublicReceiverPath,\n      target: TeleportedTetherToken.TokenStoragePath\n    )\n    signer.link<&TeleportedTetherToken.Vault{FungibleToken.Balance}>(\n      TeleportedTetherToken.TokenPublicBalancePath,\n      target: TeleportedTetherToken.TokenStoragePath\n    )\n  }\n    let teleportedTetherTokenVault = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token1Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    teleportedTetherTokenVault.deposit(from: <- token1Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076010
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076020
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076031
+                    }
+                }
+            },
+            "0xBLT_USDT_SWAP_PAIR_ADDRESS": {
+                "BltUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0xc59604d4e65f14b3",
+                        "contract": "BltUsdtSwapPair",
+                        "fq_address": "A.0xc59604d4e65f14b3.BltUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076057
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-exact-flow-for-blocto-token.json
+++ b/templates/Blocto/bloctoswap-swap-exact-flow-for-blocto-token.json
@@ -1,0 +1,93 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "857951f000c4d35cb181c2252c01c817eef020cc980a8d392e1aa7cc36a44cce",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap exact flow for blocto token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {amountIn} FLOW for at least {minAmountOut} BLT",
+                    "zh-CN": "将 {amountIn} FLOW 兑换成至少 {minAmountOut} BLT",
+                    "zh-TW": "將 {amountIn} FLOW 兌換成至少 {minAmountOut} BLT"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\nimport BltUsdtSwapPair from 0xBLT_USDT_SWAP_PAIR_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- flowTokenVault.withdraw(amount: amountIn) as! @FlowToken.Vault\n    let token1Vault <- FlowSwapPair.swapToken1ForToken2(from: <- token0Vault)\nlet token2Vault <- BltUsdtSwapPair.swapToken2ForToken1(from: <- token1Vault)\n\n      if signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) == nil {\n    signer.save(<-BloctoToken.createEmptyVault(), to: /storage/bloctoTokenVault)\n    signer.link<&BloctoToken.Vault{FungibleToken.Receiver}>(\n      /public/bloctoTokenReceiver,\n      target: /storage/bloctoTokenVault\n    )\n    signer.link<&BloctoToken.Vault{FungibleToken.Balance}>(\n      /public/bloctoTokenBalance,\n      target: /storage/bloctoTokenVault\n    )\n  }\n    let bloctoTokenVault = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token2Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    bloctoTokenVault.deposit(from: <- token2Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075962
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075970
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075995
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076020
+                    }
+                }
+            },
+            "0xBLT_USDT_SWAP_PAIR_ADDRESS": {
+                "BltUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0xc59604d4e65f14b3",
+                        "contract": "BltUsdtSwapPair",
+                        "fq_address": "A.0xc59604d4e65f14b3.BltUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076050
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-exact-flow-token-for-fusd.json
+++ b/templates/Blocto/bloctoswap-swap-exact-flow-token-for-fusd.json
@@ -1,0 +1,93 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ed8071162f96948f2235dd7aab156a4d5b4910fa6a8b35f599b03008ac23f008",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap exact flow token for fusd"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {amountIn} FLOW for at least {minAmountOut} FUSD",
+                    "zh-CN": "将 {amountIn} FLOW 兑换成至少 {minAmountOut} FUSD",
+                    "zh-TW": "將 {amountIn} FLOW 兌換成至少 {minAmountOut} FUSD"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- flowTokenVault.withdraw(amount: amountIn) as! @FlowToken.Vault\n    let token1Vault <- FlowSwapPair.swapToken1ForToken2(from: <- token0Vault)\nlet token2Vault <- FusdUsdtSwapPair.swapToken2ForToken1(from: <- token1Vault)\n\n      if signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) == nil {\n    signer.save(<-FUSD.createEmptyVault(), to: /storage/fusdVault)\n    signer.link<&FUSD.Vault{FungibleToken.Receiver}>(\n      /public/fusdReceiver,\n      target: /storage/fusdVault\n    )\n    signer.link<&FUSD.Vault{FungibleToken.Balance}>(\n      /public/fusdBalance,\n      target: /storage/fusdVault\n    )\n  }\n    let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token2Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    fusdVault.deposit(from: <- token2Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076019
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076031
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076046
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076066
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076103
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-exact-flow-token-for-usdt.json
+++ b/templates/Blocto/bloctoswap-swap-exact-flow-token-for-usdt.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ba3767402d14f81b36aa8222027f5988b31887103efc7881b730245dc55b2597",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap exact flow token for usdt"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {amountIn} FLOW for at least {minAmountOut} tUSDT",
+                    "zh-CN": "将 {amountIn} FLOW 兑换成至少 {minAmountOut} tUSDT",
+                    "zh-TW": "將 {amountIn} FLOW 兌換成至少 {minAmountOut} tUSDT"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- flowTokenVault.withdraw(amount: amountIn) as! @FlowToken.Vault\n    let token1Vault <- FlowSwapPair.swapToken1ForToken2(from: <- token0Vault)\n\n      if signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) == nil {\n    signer.save(<-TeleportedTetherToken.createEmptyVault(), to: TeleportedTetherToken.TokenStoragePath)\n    signer.link<&TeleportedTetherToken.Vault{FungibleToken.Receiver}>(\n      TeleportedTetherToken.TokenPublicReceiverPath,\n      target: TeleportedTetherToken.TokenStoragePath\n    )\n    signer.link<&TeleportedTetherToken.Vault{FungibleToken.Balance}>(\n      TeleportedTetherToken.TokenPublicBalancePath,\n      target: TeleportedTetherToken.TokenStoragePath\n    )\n  }\n    let teleportedTetherTokenVault = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token1Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    teleportedTetherTokenVault.deposit(from: <- token1Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076057
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076066
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076077
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076112
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-exact-fusd-for-blocto-token.json
+++ b/templates/Blocto/bloctoswap-swap-exact-fusd-for-blocto-token.json
@@ -1,0 +1,93 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "f212e5d3d64ecc1004a3a257c13065a4d512a3a02e99f35c36aaae13247afa41",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap exact fusd for blocto token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {amountIn} FUSD for at least {minAmountOut} BLT",
+                    "zh-CN": "将 {amountIn} FUSD 兑换成至少 {minAmountOut} BLT",
+                    "zh-TW": "將 {amountIn} FUSD 兌換成至少 {minAmountOut} BLT"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\nimport BltUsdtSwapPair from 0xBLT_USDT_SWAP_PAIR_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- fusdVault.withdraw(amount: amountIn) as! @FUSD.Vault\n    let token1Vault <- FusdUsdtSwapPair.swapToken1ForToken2(from: <- token0Vault)\nlet token2Vault <- BltUsdtSwapPair.swapToken2ForToken1(from: <- token1Vault)\n\n      if signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) == nil {\n    signer.save(<-BloctoToken.createEmptyVault(), to: /storage/bloctoTokenVault)\n    signer.link<&BloctoToken.Vault{FungibleToken.Receiver}>(\n      /public/bloctoTokenReceiver,\n      target: /storage/bloctoTokenVault\n    )\n    signer.link<&BloctoToken.Vault{FungibleToken.Balance}>(\n      /public/bloctoTokenBalance,\n      target: /storage/bloctoTokenVault\n    )\n  }\n    let bloctoTokenVault = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token2Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    bloctoTokenVault.deposit(from: <- token2Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076059
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076066
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076078
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076111
+                    }
+                }
+            },
+            "0xBLT_USDT_SWAP_PAIR_ADDRESS": {
+                "BltUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0xc59604d4e65f14b3",
+                        "contract": "BltUsdtSwapPair",
+                        "fq_address": "A.0xc59604d4e65f14b3.BltUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076133
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-exact-fusd-for-flow-token.json
+++ b/templates/Blocto/bloctoswap-swap-exact-fusd-for-flow-token.json
@@ -1,0 +1,93 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "1e8ce843c6394d6388556c52bc4df539c27839b9ddf8d81d6df7c488352bdfa9",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap exact fusd for flow token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {amountIn} FUSD for at least {minAmountOut} FLOW",
+                    "zh-CN": "将 {amountIn} FUSD 兑换成至少 {minAmountOut} FLOW",
+                    "zh-TW": "將 {amountIn} FUSD 兌換成至少 {minAmountOut} FLOW"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- fusdVault.withdraw(amount: amountIn) as! @FUSD.Vault\n    let token1Vault <- FusdUsdtSwapPair.swapToken1ForToken2(from: <- token0Vault)\nlet token2Vault <- FlowSwapPair.swapToken2ForToken1(from: <- token1Vault)\n\n      if signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) == nil {\n    signer.save(<-FlowToken.createEmptyVault(), to: /storage/flowTokenVault)\n    signer.link<&FlowToken.Vault{FungibleToken.Receiver}>(\n      /public/flowTokenReceiver,\n      target: /storage/flowTokenVault\n    )\n    signer.link<&FlowToken.Vault{FungibleToken.Balance}>(\n      /public/flowTokenBalance,\n      target: /storage/flowTokenVault\n    )\n  }\n    let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token2Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    flowTokenVault.deposit(from: <- token2Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076057
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076066
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076078
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076109
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076130
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-exact-fusd-for-usdt.json
+++ b/templates/Blocto/bloctoswap-swap-exact-fusd-for-usdt.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "61cd6bb98fcd01ca189b56d61cb1b0aded73bd7224304c888ff71d4ca72b637a",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap exact fusd for usdt"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {amountIn} FUSD for at least {minAmountOut} tUSDT",
+                    "zh-CN": "将 {amountIn} FUSD 兑换成至少 {minAmountOut} tUSDT",
+                    "zh-TW": "將 {amountIn} FUSD 兌換成至少 {minAmountOut} tUSDT"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- fusdVault.withdraw(amount: amountIn) as! @FUSD.Vault\n    let token1Vault <- FusdUsdtSwapPair.swapToken1ForToken2(from: <- token0Vault)\n\n      if signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) == nil {\n    signer.save(<-TeleportedTetherToken.createEmptyVault(), to: TeleportedTetherToken.TokenStoragePath)\n    signer.link<&TeleportedTetherToken.Vault{FungibleToken.Receiver}>(\n      TeleportedTetherToken.TokenPublicReceiverPath,\n      target: TeleportedTetherToken.TokenStoragePath\n    )\n    signer.link<&TeleportedTetherToken.Vault{FungibleToken.Balance}>(\n      TeleportedTetherToken.TokenPublicBalancePath,\n      target: TeleportedTetherToken.TokenStoragePath\n    )\n  }\n    let teleportedTetherTokenVault = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token1Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    teleportedTetherTokenVault.deposit(from: <- token1Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076066
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076078
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076097
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076123
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-exact-usdt-for-blocto-token.json
+++ b/templates/Blocto/bloctoswap-swap-exact-usdt-for-blocto-token.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "09f4ba4e5eda1996e44ee7865eddba96562073e5423b5aea5e3c0db94551a8d6",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap exact usdt for blocto token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {amountIn} tUSDT for at least {minAmountOut} BLT",
+                    "zh-CN": "将 {amountIn} tUSDT 兑换成至少 {minAmountOut} BLT",
+                    "zh-TW": "將 {amountIn} tUSDT 兌換成至少 {minAmountOut} BLT"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport BltUsdtSwapPair from 0xBLT_USDT_SWAP_PAIR_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let teleportedTetherTokenVault = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- teleportedTetherTokenVault.withdraw(amount: amountIn) as! @TeleportedTetherToken.Vault\n    let token1Vault <- BltUsdtSwapPair.swapToken2ForToken1(from: <- token0Vault)\n\n      if signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) == nil {\n    signer.save(<-BloctoToken.createEmptyVault(), to: /storage/bloctoTokenVault)\n    signer.link<&BloctoToken.Vault{FungibleToken.Receiver}>(\n      /public/bloctoTokenReceiver,\n      target: /storage/bloctoTokenVault\n    )\n    signer.link<&BloctoToken.Vault{FungibleToken.Balance}>(\n      /public/bloctoTokenBalance,\n      target: /storage/bloctoTokenVault\n    )\n  }\n    let bloctoTokenVault = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token1Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    bloctoTokenVault.deposit(from: <- token1Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076112
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076126
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076133
+                    }
+                }
+            },
+            "0xBLT_USDT_SWAP_PAIR_ADDRESS": {
+                "BltUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0xc59604d4e65f14b3",
+                        "contract": "BltUsdtSwapPair",
+                        "fq_address": "A.0xc59604d4e65f14b3.BltUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076162
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-exact-usdt-for-flow-token.json
+++ b/templates/Blocto/bloctoswap-swap-exact-usdt-for-flow-token.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "7f1b70f3f91eefe263ab6692637f1ae1e068a33e6edcfc5ee0f23f9718b8e2d6",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap exact usdt for flow token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {amountIn} tUSDT for at least {minAmountOut} FLOW",
+                    "zh-CN": "将 {amountIn} tUSDT 兑换成至少 {minAmountOut} FLOW",
+                    "zh-TW": "將 {amountIn} tUSDT 兌換成至少 {minAmountOut} FLOW"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let teleportedTetherTokenVault = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- teleportedTetherTokenVault.withdraw(amount: amountIn) as! @TeleportedTetherToken.Vault\n    let token1Vault <- FlowSwapPair.swapToken2ForToken1(from: <- token0Vault)\n\n      if signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) == nil {\n    signer.save(<-FlowToken.createEmptyVault(), to: /storage/flowTokenVault)\n    signer.link<&FlowToken.Vault{FungibleToken.Receiver}>(\n      /public/flowTokenReceiver,\n      target: /storage/flowTokenVault\n    )\n    signer.link<&FlowToken.Vault{FungibleToken.Balance}>(\n      /public/flowTokenBalance,\n      target: /storage/flowTokenVault\n    )\n  }\n    let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token1Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    flowTokenVault.deposit(from: <- token1Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076123
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076133
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076144
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076166
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-exact-usdt-for-fusd.json
+++ b/templates/Blocto/bloctoswap-swap-exact-usdt-for-fusd.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "0186c96d2301ddec1f8b1a2154bfb6ae8958a7e7f8c294c71793c7ac0ada0eb3",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap exact usdt for fusd"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap {amountIn} tUSDT for at least {minAmountOut} FUSD",
+                    "zh-CN": "将 {amountIn} tUSDT 兑换成至少 {minAmountOut} FUSD",
+                    "zh-TW": "將 {amountIn} tUSDT 兌換成至少 {minAmountOut} FUSD"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let teleportedTetherTokenVault = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- teleportedTetherTokenVault.withdraw(amount: amountIn) as! @TeleportedTetherToken.Vault\n    let token1Vault <- FusdUsdtSwapPair.swapToken2ForToken1(from: <- token0Vault)\n\n      if signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) == nil {\n    signer.save(<-FUSD.createEmptyVault(), to: /storage/fusdVault)\n    signer.link<&FUSD.Vault{FungibleToken.Receiver}>(\n      /public/fusdReceiver,\n      target: /storage/fusdVault\n    )\n    signer.link<&FUSD.Vault{FungibleToken.Balance}>(\n      /public/fusdBalance,\n      target: /storage/fusdVault\n    )\n  }\n    let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token1Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    fusdVault.deposit(from: <- token1Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076128
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076133
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076144
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076179
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-flow-token-for-exact-blocto-token.json
+++ b/templates/Blocto/bloctoswap-swap-flow-token-for-exact-blocto-token.json
@@ -1,0 +1,93 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "1a1d8457c4b19162ab72463f0057c852eb2e535fb31b4d2187bd76bdd1d02ba4",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap flow token for exact blocto token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap at most {maxAmountIn} FLOW for {amountOut} BLT",
+                    "zh-CN": "将最多 {maxAmountIn} FLOW 兑换成 {amountOut} BLT",
+                    "zh-TW": "將最多 {maxAmountIn} FLOW 兌換成 {amountOut} BLT"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\nimport BltUsdtSwapPair from 0xBLT_USDT_SWAP_PAIR_ADDRESS\n\ntransaction(maxAmountIn: UFix64, amountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    let amount0 = BltUsdtSwapPair.quoteSwapToken2ForExactToken1(amount: amountOut) / (1.0 - BltUsdtSwapPair.getFeePercentage())\nlet amountIn = FlowSwapPair.quoteSwapToken1ForExactToken2(amount: amount0) / (1.0 - FlowSwapPair.getFeePercentage())\n    assert(amountIn <= maxAmountIn, message: \"Input amount too large\")\n\n    let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- flowTokenVault.withdraw(amount: amountIn) as! @FlowToken.Vault\n    let token1Vault <- FlowSwapPair.swapToken1ForToken2(from: <- token0Vault)\nlet token2Vault <- BltUsdtSwapPair.swapToken2ForToken1(from: <- token1Vault)\n\n      if signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) == nil {\n    signer.save(<-BloctoToken.createEmptyVault(), to: /storage/bloctoTokenVault)\n    signer.link<&BloctoToken.Vault{FungibleToken.Receiver}>(\n      /public/bloctoTokenReceiver,\n      target: /storage/bloctoTokenVault\n    )\n    signer.link<&BloctoToken.Vault{FungibleToken.Balance}>(\n      /public/bloctoTokenBalance,\n      target: /storage/bloctoTokenVault\n    )\n  }\n    let bloctoTokenVault = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    \n\n    bloctoTokenVault.deposit(from: <- token2Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076136
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076144
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076162
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076186
+                    }
+                }
+            },
+            "0xBLT_USDT_SWAP_PAIR_ADDRESS": {
+                "BltUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0xc59604d4e65f14b3",
+                        "contract": "BltUsdtSwapPair",
+                        "fq_address": "A.0xc59604d4e65f14b3.BltUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076217
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "maxAmountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "amountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-flow-token-for-exact-fusd.json
+++ b/templates/Blocto/bloctoswap-swap-flow-token-for-exact-fusd.json
@@ -1,0 +1,93 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "571d15fcf5d942e58003064bce63f5d3b99fd2b6557c9ce553bc4a2b153471c6",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap flow token for exact fusd"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap at most {maxAmountIn} FLOW for {amountOut} FUSD",
+                    "zh-CN": "将至多 {maxAmountIn} FLOW 兑换成 {amountOut} FUSD",
+                    "zh-TW": "將至多 {maxAmountIn} FLOW 兌換成 {amountOut} FUSD"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\n\ntransaction(maxAmountIn: UFix64, amountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    let amount0 = FusdUsdtSwapPair.quoteSwapToken2ForExactToken1(amount: amountOut) / (1.0 - FusdUsdtSwapPair.getFeePercentage())\nlet amountIn = FlowSwapPair.quoteSwapToken1ForExactToken2(amount: amount0) / (1.0 - FlowSwapPair.getFeePercentage())\n    assert(amountIn <= maxAmountIn, message: \"Input amount too large\")\n\n    let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- flowTokenVault.withdraw(amount: amountIn) as! @FlowToken.Vault\n    let token1Vault <- FlowSwapPair.swapToken1ForToken2(from: <- token0Vault)\nlet token2Vault <- FusdUsdtSwapPair.swapToken2ForToken1(from: <- token1Vault)\n\n      if signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) == nil {\n    signer.save(<-FUSD.createEmptyVault(), to: /storage/fusdVault)\n    signer.link<&FUSD.Vault{FungibleToken.Receiver}>(\n      /public/fusdReceiver,\n      target: /storage/fusdVault\n    )\n    signer.link<&FUSD.Vault{FungibleToken.Balance}>(\n      /public/fusdBalance,\n      target: /storage/fusdVault\n    )\n  }\n    let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    \n\n    fusdVault.deposit(from: <- token2Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076141
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076154
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076162
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076186
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076218
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "maxAmountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "amountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-flow-token-for-exact-usdt.json
+++ b/templates/Blocto/bloctoswap-swap-flow-token-for-exact-usdt.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "eea6c83d96a859242f9c71441527e30437083e4dd44492400ee998595abdd948",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap flow token for exact usdt"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap at most {maxAmountIn} FLOW for {amountOut} tUSDT",
+                    "zh-CN": "将至多 {maxAmountIn} FLOW 兑换成 {amountOut} tUSDT",
+                    "zh-TW": "將至多 {maxAmountIn} FLOW 兌換成 {amountOut} tUSDT"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\n\ntransaction(maxAmountIn: UFix64, amountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    let amountIn = FlowSwapPair.quoteSwapToken1ForExactToken2(amount: amountOut) / (1.0 - FlowSwapPair.getFeePercentage())\n    assert(amountIn <= maxAmountIn, message: \"Input amount too large\")\n\n    let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- flowTokenVault.withdraw(amount: amountIn) as! @FlowToken.Vault\n    let token1Vault <- FlowSwapPair.swapToken1ForToken2(from: <- token0Vault)\n\n      if signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) == nil {\n    signer.save(<-TeleportedTetherToken.createEmptyVault(), to: TeleportedTetherToken.TokenStoragePath)\n    signer.link<&TeleportedTetherToken.Vault{FungibleToken.Receiver}>(\n      TeleportedTetherToken.TokenPublicReceiverPath,\n      target: TeleportedTetherToken.TokenStoragePath\n    )\n    signer.link<&TeleportedTetherToken.Vault{FungibleToken.Balance}>(\n      TeleportedTetherToken.TokenPublicBalancePath,\n      target: TeleportedTetherToken.TokenStoragePath\n    )\n  }\n    let teleportedTetherTokenVault = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    \n\n    teleportedTetherTokenVault.deposit(from: <- token1Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076175
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076184
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076189
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076219
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "maxAmountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "amountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-fusd-for-exact-blocto-token.json
+++ b/templates/Blocto/bloctoswap-swap-fusd-for-exact-blocto-token.json
@@ -1,0 +1,93 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "74d066dda12875ee83b28ee8eba842d37b37ff7bd6fd79a7c48eb52cfa16cbff",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap fusd for exact blocto token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap at most {maxAmountIn} FUSD for {amountOut} BLT",
+                    "zh-CN": "将最多 {maxAmountIn} FUSD 兑换成 {amountOut} BLT",
+                    "zh-TW": "將最多 {maxAmountIn} FUSD 兌換成 {amountOut} BLT"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\nimport BltUsdtSwapPair from 0xBLT_USDT_SWAP_PAIR_ADDRESS\n\ntransaction(maxAmountIn: UFix64, amountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    let amount0 = BltUsdtSwapPair.quoteSwapToken2ForExactToken1(amount: amountOut) / (1.0 - BltUsdtSwapPair.getFeePercentage())\nlet amountIn = FusdUsdtSwapPair.quoteSwapToken1ForExactToken2(amount: amount0) / (1.0 - FusdUsdtSwapPair.getFeePercentage())\n    assert(amountIn <= maxAmountIn, message: \"Input amount too large\")\n\n    let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- fusdVault.withdraw(amount: amountIn) as! @FUSD.Vault\n    let token1Vault <- FusdUsdtSwapPair.swapToken1ForToken2(from: <- token0Vault)\nlet token2Vault <- BltUsdtSwapPair.swapToken2ForToken1(from: <- token1Vault)\n\n      if signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) == nil {\n    signer.save(<-BloctoToken.createEmptyVault(), to: /storage/bloctoTokenVault)\n    signer.link<&BloctoToken.Vault{FungibleToken.Receiver}>(\n      /public/bloctoTokenReceiver,\n      target: /storage/bloctoTokenVault\n    )\n    signer.link<&BloctoToken.Vault{FungibleToken.Balance}>(\n      /public/bloctoTokenBalance,\n      target: /storage/bloctoTokenVault\n    )\n  }\n    let bloctoTokenVault = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    \n\n    bloctoTokenVault.deposit(from: <- token2Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076176
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076186
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076197
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076229
+                    }
+                }
+            },
+            "0xBLT_USDT_SWAP_PAIR_ADDRESS": {
+                "BltUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0xc59604d4e65f14b3",
+                        "contract": "BltUsdtSwapPair",
+                        "fq_address": "A.0xc59604d4e65f14b3.BltUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076264
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "maxAmountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "amountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-fusd-for-exact-flow-token.json
+++ b/templates/Blocto/bloctoswap-swap-fusd-for-exact-flow-token.json
@@ -1,0 +1,93 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "da1ebe9105f78103cbd5ba19a60c53bb1a3bc27e5878dd4e7e85a3273a6ee025",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap fusd for exact flow token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap at most {maxAmountIn} FUSD for {amountOut} FLOW",
+                    "zh-CN": "将至多 {maxAmountIn} FUSD 兑换成 {amountOut} FLOW",
+                    "zh-TW": "將至多 {maxAmountIn} FUSD 兌換成 {amountOut} FLOW"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\n\ntransaction(maxAmountIn: UFix64, amountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    let amount0 = FlowSwapPair.quoteSwapToken2ForExactToken1(amount: amountOut) / (1.0 - FlowSwapPair.getFeePercentage())\nlet amountIn = FusdUsdtSwapPair.quoteSwapToken1ForExactToken2(amount: amount0) / (1.0 - FusdUsdtSwapPair.getFeePercentage())\n    assert(amountIn <= maxAmountIn, message: \"Input amount too large\")\n\n    let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- fusdVault.withdraw(amount: amountIn) as! @FUSD.Vault\n    let token1Vault <- FusdUsdtSwapPair.swapToken1ForToken2(from: <- token0Vault)\nlet token2Vault <- FlowSwapPair.swapToken2ForToken1(from: <- token1Vault)\n\n      if signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) == nil {\n    signer.save(<-FlowToken.createEmptyVault(), to: /storage/flowTokenVault)\n    signer.link<&FlowToken.Vault{FungibleToken.Receiver}>(\n      /public/flowTokenReceiver,\n      target: /storage/flowTokenVault\n    )\n    signer.link<&FlowToken.Vault{FungibleToken.Balance}>(\n      /public/flowTokenBalance,\n      target: /storage/flowTokenVault\n    )\n  }\n    let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    \n\n    flowTokenVault.deposit(from: <- token2Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076188
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076200
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076218
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076235
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076275
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "maxAmountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "amountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-fusd-for-exact-usdt.json
+++ b/templates/Blocto/bloctoswap-swap-fusd-for-exact-usdt.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "cf289663b20e2b88348d448a15deefe0a34c8f6cf62f83cc38650a5f0d0abf9a",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap fusd for exact usdt"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap at most {maxAmountIn} FUSD for {amountOut} USDT",
+                    "zh-CN": "将最多 {maxAmountIn} FUSD 兑换成 {amountOut} USDT",
+                    "zh-TW": "將最多 {maxAmountIn} FUSD 兌換成 {amountOut} USDT"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\n\ntransaction(maxAmountIn: UFix64, amountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    let amountIn = FusdUsdtSwapPair.quoteSwapToken1ForExactToken2(amount: amountOut) / (1.0 - FusdUsdtSwapPair.getFeePercentage())\n    assert(amountIn <= maxAmountIn, message: \"Input amount too large\")\n\n    let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- fusdVault.withdraw(amount: amountIn) as! @FUSD.Vault\n    let token1Vault <- FusdUsdtSwapPair.swapToken1ForToken2(from: <- token0Vault)\n\n      if signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) == nil {\n    signer.save(<-TeleportedTetherToken.createEmptyVault(), to: TeleportedTetherToken.TokenStoragePath)\n    signer.link<&TeleportedTetherToken.Vault{FungibleToken.Receiver}>(\n      TeleportedTetherToken.TokenPublicReceiverPath,\n      target: TeleportedTetherToken.TokenStoragePath\n    )\n    signer.link<&TeleportedTetherToken.Vault{FungibleToken.Balance}>(\n      TeleportedTetherToken.TokenPublicBalancePath,\n      target: TeleportedTetherToken.TokenStoragePath\n    )\n  }\n    let teleportedTetherTokenVault = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    \n\n    teleportedTetherTokenVault.deposit(from: <- token1Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076219
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076233
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076242
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076275
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "maxAmountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "amountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-usdt-for-exact-blocto-token.json
+++ b/templates/Blocto/bloctoswap-swap-usdt-for-exact-blocto-token.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "1b19507f7018b4e0def5c4c816ebc89562801dffd41cbdaec1d5094731d6cc77",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap usdt for exact blocto token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap at most {maxAmountIn} tUSDT for {amountOut} BLT",
+                    "zh-CN": "将最多 {maxAmountIn} tUSDT 兑换成 {amountOut} BLT",
+                    "zh-TW": "將最多 {maxAmountIn} tUSDT 兌換成 {amountOut} BLT"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport BltUsdtSwapPair from 0xBLT_USDT_SWAP_PAIR_ADDRESS\n\ntransaction(maxAmountIn: UFix64, amountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    let amountIn = BltUsdtSwapPair.quoteSwapToken2ForExactToken1(amount: amountOut) / (1.0 - BltUsdtSwapPair.getFeePercentage())\n    assert(amountIn <= maxAmountIn, message: \"Input amount too large\")\n\n    let teleportedTetherTokenVault = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- teleportedTetherTokenVault.withdraw(amount: amountIn) as! @TeleportedTetherToken.Vault\n    let token1Vault <- BltUsdtSwapPair.swapToken2ForToken1(from: <- token0Vault)\n\n      if signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) == nil {\n    signer.save(<-BloctoToken.createEmptyVault(), to: /storage/bloctoTokenVault)\n    signer.link<&BloctoToken.Vault{FungibleToken.Receiver}>(\n      /public/bloctoTokenReceiver,\n      target: /storage/bloctoTokenVault\n    )\n    signer.link<&BloctoToken.Vault{FungibleToken.Balance}>(\n      /public/bloctoTokenBalance,\n      target: /storage/bloctoTokenVault\n    )\n  }\n    let bloctoTokenVault = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    \n\n    bloctoTokenVault.deposit(from: <- token1Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076225
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076233
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076245
+                    }
+                }
+            },
+            "0xBLT_USDT_SWAP_PAIR_ADDRESS": {
+                "BltUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0xc59604d4e65f14b3",
+                        "contract": "BltUsdtSwapPair",
+                        "fq_address": "A.0xc59604d4e65f14b3.BltUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076275
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "maxAmountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "amountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-usdt-for-exact-flow-token.json
+++ b/templates/Blocto/bloctoswap-swap-usdt-for-exact-flow-token.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "093f10dea2571e2ca593ae8908c7a7b4c81cf809de275ffcc5b1f6784c11e619",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap usdt for exact flow token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap at most {maxAmountIn} tUSDT for {amountOut} FLOW",
+                    "zh-CN": "将最多 {maxAmountIn} tUSDT 兑换成 {amountOut} FLOW",
+                    "zh-TW": "將最多 {maxAmountIn} tUSDT 兌換成 {amountOut} FLOW"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\n\ntransaction(maxAmountIn: UFix64, amountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    let amountIn = FlowSwapPair.quoteSwapToken2ForExactToken1(amount: amountOut) / (1.0 - FlowSwapPair.getFeePercentage())\n    assert(amountIn <= maxAmountIn, message: \"Input amount too large\")\n\n    let teleportedTetherTokenVault = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- teleportedTetherTokenVault.withdraw(amount: amountIn) as! @TeleportedTetherToken.Vault\n    let token1Vault <- FlowSwapPair.swapToken2ForToken1(from: <- token0Vault)\n\n      if signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) == nil {\n    signer.save(<-FlowToken.createEmptyVault(), to: /storage/flowTokenVault)\n    signer.link<&FlowToken.Vault{FungibleToken.Receiver}>(\n      /public/flowTokenReceiver,\n      target: /storage/flowTokenVault\n    )\n    signer.link<&FlowToken.Vault{FungibleToken.Balance}>(\n      /public/flowTokenBalance,\n      target: /storage/flowTokenVault\n    )\n  }\n    let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    \n\n    flowTokenVault.deposit(from: <- token1Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076226
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076233
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076245
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076275
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "maxAmountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "amountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctoswap-swap-usdt-for-exact-fusd.json
+++ b/templates/Blocto/bloctoswap-swap-usdt-for-exact-fusd.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ce06ca4d8a00a2dd002350d4dc21ad2b428646bbd566e700639ab7b14b03972d",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoSwap Swap usdt for exact fusd"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Swap at most {maxAmountIn} tUSDT for {amountOut} FUSD",
+                    "zh-CN": "将最多 {maxAmountIn} tUSDT 兑换成 {amountOut} FUSD",
+                    "zh-TW": "將最多 {maxAmountIn} tUSDT 兌換成 {amountOut} FUSD"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\n\ntransaction(amountIn: UFix64, minAmountOut: UFix64) {\n  prepare(signer: AuthAccount) {\n    \n    \n\n    let teleportedTetherTokenVault = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    let token0Vault <- teleportedTetherTokenVault.withdraw(amount: amountIn) as! @TeleportedTetherToken.Vault\n    let token1Vault <- FusdUsdtSwapPair.swapToken2ForToken1(from: <- token0Vault)\n\n      if signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) == nil {\n    signer.save(<-FUSD.createEmptyVault(), to: /storage/fusdVault)\n    signer.link<&FUSD.Vault{FungibleToken.Receiver}>(\n      /public/fusdReceiver,\n      target: /storage/fusdVault\n    )\n    signer.link<&FUSD.Vault{FungibleToken.Balance}>(\n      /public/fusdBalance,\n      target: /storage/fusdVault\n    )\n  }\n    let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) \n      ?? panic(\"Could not borrow a reference to Vault\")\n\n    assert(token1Vault.balance >= minAmountOut, message: \"Output amount too small\")\n\n    fusdVault.deposit(from: <- token1Vault)\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076275
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076286
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076315
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 139076395
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amountIn": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "minAmountOut": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bloctotoken-send-blocto-token.json
+++ b/templates/Blocto/bloctotoken-send-blocto-token.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "6f379079833323643dbf093688a34564dba3c7c6ed7df1929e799917de959b07",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BloctoToken Send blocto token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Send {amount} BLT to {to}",
+                    "zh-CN": "发送 {amount} BLT 代币至 {to}",
+                    "zh-TW": "發送 {amount} BLT 代幣至 {to}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\n\ntransaction(amount: UFix64, to: Address) {\n    let sentVault: @FungibleToken.Vault\n    prepare(signer: AuthAccount) {\n        let vaultRef = signer.borrow<&BloctoToken.Vault>(from: /storage/bloctoTokenVault)\n            ?? panic(\"Could not borrow reference to the owner's Vault!\")\n        self.sentVault <- vaultRef.withdraw(amount: amount)\n    }\n\n    execute {\n        let recipient = getAccount(to)\n        let receiverRef = recipient.getCapability(/public/bloctoTokenReceiver)!.borrow<&{FungibleToken.Receiver}>()\n            ?? panic(\"Could not borrow receiver reference to the recipient's Vault\")\n        receiverRef.deposit(from: <-self.sentVault)\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075532
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075554
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "to": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bltstaking-claim-reward-blt.json
+++ b/templates/Blocto/bltstaking-claim-reward-blt.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "e3dc3ada3857148f5e20d7de2da87c426410b9cfc4a530d493160f68f0a07cdc",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BltStaking Claim reward blt"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Claim staking reward: {amount} BLT",
+                    "zh-CN": "领取质押奖励: {amount} BLT 代币",
+                    "zh-TW": "領取質押獎勵: {amount} BLT 代幣"
+                }
+            }
+        },
+        "cadence": "import BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport BloctoPass from 0xBLOCTO_PASS_ADDRESS\n\ntransaction(amount: UFix64, index: Int) {\n\n  // The Vault resource that holds the tokens that are being transferred\n  let vaultRef: &BloctoToken.Vault\n\n  // The private reference to user's BloctoPass\n  let bloctoPassRef: &BloctoPass.NFT\n\n  prepare(account: AuthAccount) {\n    // Get a reference to the account's stored vault\n    self.vaultRef = account.borrow<&BloctoToken.Vault>(from: BloctoToken.TokenStoragePath)\n      ?? panic(\"Could not borrow reference to the owner's Vault!\")\n\n    // Get a reference to the account's BloctoPass\n    let bloctoPassCollectionRef = account.borrow<&BloctoPass.Collection>(from: /storage/bloctoPassCollection)\n      ?? panic(\"Could not borrow reference to the owner's BloctoPass collection!\")\n\n    let ids = bloctoPassCollectionRef.getIDs()\n\n    // Get a reference to the BloctoPass\n    self.bloctoPassRef = bloctoPassCollectionRef.borrowBloctoPassPrivate(id: ids[index])\n  }\n\n  execute {\n    self.bloctoPassRef.withdrawRewardedTokens(amount: amount)\n\n    // Unlock as much as possible\n    let limit = self.bloctoPassRef.getTotalBalance() - self.bloctoPassRef.getLockupAmount()\n    let max = limit > amount ? amount : limit\n\n    self.vaultRef.deposit(from: <-self.bloctoPassRef.withdraw(amount: max))\n  }\n}",
+        "dependencies": {
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076288
+                    }
+                }
+            },
+            "0xBLOCTO_PASS_ADDRESS": {
+                "BloctoPass": {
+                    "testnet": {
+                        "address": "0x7deafdfc288e422d",
+                        "contract": "BloctoPass",
+                        "fq_address": "A.0x7deafdfc288e422d.BloctoPass",
+                        "pin": "3c7796c792dc130c2e565c8246de8a8d5add43e7f340efe20c52568c43602b36",
+                        "pin_block_height": 139076430
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "index": {
+                "index": 1,
+                "type": "Int",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bltstaking-claim-unstaked-blt.json
+++ b/templates/Blocto/bltstaking-claim-unstaked-blt.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "effb1fbd83990de8c97fe9063827dfb6aade690f82eb846576b4f238b6e32496",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BltStaking Claim unstaked blt"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Claim unstaked tokens: {amount} BLT",
+                    "zh-CN": "領取解除质押的代币: {amount} BLT 代币",
+                    "zh-TW": "領取解除質押的代幣: {amount} BLT 代幣"
+                }
+            }
+        },
+        "cadence": "import BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport BloctoPass from 0xBLOCTO_PASS_ADDRESS\n\ntransaction(amount: UFix64, index: Int) {\n\n  // The Vault resource that holds the tokens that are being transferred\n  let vaultRef: &BloctoToken.Vault\n\n  // The private reference to user's BloctoPass\n  let bloctoPassRef: &BloctoPass.NFT\n\n  prepare(account: AuthAccount) {\n    // Get a reference to the account's stored vault\n    self.vaultRef = account.borrow<&BloctoToken.Vault>(from: BloctoToken.TokenStoragePath)\n      ?? panic(\"Could not borrow reference to the owner's Vault!\")\n\n    // Get a reference to the account's BloctoPass\n    let bloctoPassCollectionRef = account.borrow<&BloctoPass.Collection>(from: /storage/bloctoPassCollection)\n      ?? panic(\"Could not borrow reference to the owner's BloctoPass collection!\")\n\n    let ids = bloctoPassCollectionRef.getIDs()\n\n    // Get a reference to the BloctoPass\n    self.bloctoPassRef = bloctoPassCollectionRef.borrowBloctoPassPrivate(id: ids[index])\n  }\n\n  execute {\n    self.bloctoPassRef.withdrawUnstakedTokens(amount: amount)\n\n    // Unlock as much as possible\n    let limit = self.bloctoPassRef.getTotalBalance() - self.bloctoPassRef.getLockupAmount()\n    let max = limit > amount ? amount : limit\n    \n    if (max > 0.0) {\n      self.vaultRef.deposit(from: <-self.bloctoPassRef.withdraw(amount: max))\n    }\n  } \n}",
+        "dependencies": {
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076288
+                    }
+                }
+            },
+            "0xBLOCTO_PASS_ADDRESS": {
+                "BloctoPass": {
+                    "testnet": {
+                        "address": "0x7deafdfc288e422d",
+                        "contract": "BloctoPass",
+                        "fq_address": "A.0x7deafdfc288e422d.BloctoPass",
+                        "pin": "3c7796c792dc130c2e565c8246de8a8d5add43e7f340efe20c52568c43602b36",
+                        "pin_block_height": 139076432
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "index": {
+                "index": 1,
+                "type": "Int",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bltstaking-enable-blt-stake.json
+++ b/templates/Blocto/bltstaking-enable-blt-stake.json
@@ -1,0 +1,82 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "27a9ffbb738bbc64e4203bbaf22e342cf6f4b7c5440fab4e8a8a48c685d9be95",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BltStaking Enable blt stake"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Enable staking: {amount} BLT",
+                    "zh-CN": "启用质押: {amount} BLT 代币",
+                    "zh-TW": "啟用質押: {amount} BLT 代幣"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport BloctoPass from 0xBLOCTO_PASS_ADDRESS\n\ntransaction(amount: UFix64, index: Int) {\n\n  // The Vault resource that holds the tokens that are being transferred\n  let vaultRef: &BloctoToken.Vault\n\n  // The private reference to user's BloctoPass\n  let bloctoPassRef: &BloctoPass.NFT\n\n  prepare(signer: AuthAccount) {\n\n    // BloctoToken Vault\n    if signer.borrow<&BloctoToken.Vault>(from: BloctoToken.TokenStoragePath) == nil {\n      // Create a new Blocto Token Vault and put it in storage\n      signer.save(<-BloctoToken.createEmptyVault(), to: BloctoToken.TokenStoragePath)\n\n      // Create a public capability to the Vault that only exposes\n      // the deposit function through the Receiver interface\n      signer.link<&BloctoToken.Vault{FungibleToken.Receiver}>(\n        BloctoToken.TokenPublicReceiverPath,\n        target: BloctoToken.TokenStoragePath\n      )\n\n      // Create a public capability to the Vault that only exposes\n      // the balance field through the Balance interface\n      signer.link<&BloctoToken.Vault{FungibleToken.Balance}>(\n        BloctoToken.TokenPublicBalancePath,\n        target: BloctoToken.TokenStoragePath\n      )\n    }\n\n    // BloctoPass Collection\n    if signer.borrow<&BloctoPass.Collection>(from: /storage/bloctoPassCollection) == nil {\n      signer.save(<-BloctoPass.createEmptyCollection(), to: /storage/bloctoPassCollection)\n\n      signer.link<&{NonFungibleToken.CollectionPublic, BloctoPass.CollectionPublic}>(\n        /public/bloctoPassCollection,\n        target: /storage/bloctoPassCollection\n      )\n    }\n\n    let collectionRef = signer.getCapability(/public/bloctoPassCollection)!\n      .borrow<&{NonFungibleToken.CollectionPublic, BloctoPass.CollectionPublic}>()\n      ?? panic(\"Could not borrow collection public reference\")\n\n    if collectionRef.getIDs().length == 0 {\n      let minterRef = getAccount(0x7deafdfc288e422d).getCapability(/public/bloctoPassMinter)\n        .borrow<&{BloctoPass.MinterPublic}>()\n        ?? panic(\"Could not borrow minter public reference\")\n\n      minterRef.mintBasicNFT(recipient: collectionRef) \n    }\n\n    // Get a reference to the account's stored vault\n    self.vaultRef = signer.borrow<&BloctoToken.Vault>(from: BloctoToken.TokenStoragePath)\n      ?? panic(\"Could not borrow reference to the owner's Vault!\")\n\n    // Get a reference to the account's BloctoPass\n    let bloctoPassCollectionRef = signer.borrow<&BloctoPass.Collection>(from: /storage/bloctoPassCollection)\n      ?? panic(\"Could not borrow reference to the owner's BloctoPass collection!\")\n\n    let ids = bloctoPassCollectionRef.getIDs()\n\n    // Get a reference to the BloctoPass\n    self.bloctoPassRef = bloctoPassCollectionRef.borrowBloctoPassPrivate(id: ids[index])\n  }\n\n  execute {\n    let lockedBalance = self.bloctoPassRef.getIdleBalance()\n\n    if amount <= lockedBalance {\n      self.bloctoPassRef.stakeNewTokens(amount: amount)\n    } else if ((amount - lockedBalance) <= self.vaultRef.balance) {\n      self.bloctoPassRef.deposit(from: <-self.vaultRef.withdraw(amount: amount - lockedBalance))\n      self.bloctoPassRef.stakeNewTokens(amount: amount)\n    } else {\n      panic(\"Not enough tokens to stake!\")\n    }\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076285
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076309
+                    }
+                }
+            },
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076357
+                    }
+                }
+            },
+            "0xBLOCTO_PASS_ADDRESS": {
+                "BloctoPass": {
+                    "testnet": {
+                        "address": "0x7deafdfc288e422d",
+                        "contract": "BloctoPass",
+                        "fq_address": "A.0x7deafdfc288e422d.BloctoPass",
+                        "pin": "3c7796c792dc130c2e565c8246de8a8d5add43e7f340efe20c52568c43602b36",
+                        "pin_block_height": 139076481
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "index": {
+                "index": 1,
+                "type": "Int",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bltstaking-request-to-unstake-blt.json
+++ b/templates/Blocto/bltstaking-request-to-unstake-blt.json
@@ -1,0 +1,49 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ecc462b1269fd4e4b8e04c4faf4454c8e20cedf6c5f406500e024ecbe6cf091d",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BltStaking Request to unstake blt"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Request to unstake: {amount} BLT",
+                    "zh-CN": "请求解除质押: {amount} BLT 代币",
+                    "zh-TW": "請求解除質押: {amount} BLT 代幣"
+                }
+            }
+        },
+        "cadence": "import BloctoPass from 0xBLOCTO_PASS_ADDRESS\n\ntransaction(amount: UFix64, index: Int) {\n  // The private reference to user's BloctoPass\n  let bloctoPassRef: &BloctoPass.NFT\n\n  prepare(account: AuthAccount) {\n    // Get a reference to the account's BloctoPass\n    let bloctoPassCollectionRef = account.borrow<&BloctoPass.Collection>(from: /storage/bloctoPassCollection)\n      ?? panic(\"Could not borrow reference to the owner's BloctoPass collection!\")\n\n    let ids = bloctoPassCollectionRef.getIDs()\n\n    // Get a reference to the BloctoPass\n    self.bloctoPassRef = bloctoPassCollectionRef.borrowBloctoPassPrivate(id: ids[index])\n  }\n\n  execute {\n    self.bloctoPassRef.requestUnstaking(amount: amount)\n  }\n}",
+        "dependencies": {
+            "0xBLOCTO_PASS_ADDRESS": {
+                "BloctoPass": {
+                    "testnet": {
+                        "address": "0x7deafdfc288e422d",
+                        "contract": "BloctoPass",
+                        "fq_address": "A.0x7deafdfc288e422d.BloctoPass",
+                        "pin": "3c7796c792dc130c2e565c8246de8a8d5add43e7f340efe20c52568c43602b36",
+                        "pin_block_height": 139076395
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "index": {
+                "index": 1,
+                "type": "Int",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bltstaking-stake-new-blt.json
+++ b/templates/Blocto/bltstaking-stake-new-blt.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "572c5903ad7683b8e7dd9d1bba89102cdc35c177bf29eb9d3aab29918a872ff1",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BltStaking Stake new blt"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Request to stake: {amount} BLT",
+                    "zh-CN": "请求质押: {amount} BLT 代币",
+                    "zh-TW": "請求質押: {amount} BLT 代幣"
+                }
+            }
+        },
+        "cadence": "import BloctoToken from 0xBLOCTO_TOKEN_ADDRESS\nimport BloctoPass from 0xBLOCTO_PASS_ADDRESS\n\ntransaction(amount: UFix64, index: Int) {\n\n  // The Vault resource that holds the tokens that are being transferred\n  let vaultRef: &BloctoToken.Vault\n\n  // The private reference to user's BloctoPass\n  let bloctoPassRef: &BloctoPass.NFT\n\n  prepare(account: AuthAccount) {\n    // Get a reference to the account's stored vault\n    self.vaultRef = account.borrow<&BloctoToken.Vault>(from: BloctoToken.TokenStoragePath)\n      ?? panic(\"Could not borrow reference to the owner's Vault!\")\n\n    // Get a reference to the account's BloctoPass\n    let bloctoPassCollectionRef = account.borrow<&BloctoPass.Collection>(from: /storage/bloctoPassCollection)\n      ?? panic(\"Could not borrow reference to the owner's BloctoPass collection!\")\n\n    let ids = bloctoPassCollectionRef.getIDs()\n\n    // Get a reference to the BloctoPass\n    self.bloctoPassRef = bloctoPassCollectionRef.borrowBloctoPassPrivate(id: ids[index])\n  }\n\n  execute {\n    let lockedBalance = self.bloctoPassRef.getIdleBalance()\n\n    if amount <= lockedBalance {\n      self.bloctoPassRef.stakeNewTokens(amount: amount)\n    } else if ((amount - lockedBalance) <= self.vaultRef.balance) {\n      self.bloctoPassRef.deposit(from: <-self.vaultRef.withdraw(amount: amount - lockedBalance))\n      self.bloctoPassRef.stakeNewTokens(amount: amount)\n    } else {\n      panic(\"Not enough tokens to stake!\")\n    }\n  }\n}",
+        "dependencies": {
+            "0xBLOCTO_TOKEN_ADDRESS": {
+                "BloctoToken": {
+                    "testnet": {
+                        "address": "0x6e0797ac987005f5",
+                        "contract": "BloctoToken",
+                        "fq_address": "A.0x6e0797ac987005f5.BloctoToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076432
+                    }
+                }
+            },
+            "0xBLOCTO_PASS_ADDRESS": {
+                "BloctoPass": {
+                    "testnet": {
+                        "address": "0x7deafdfc288e422d",
+                        "contract": "BloctoPass",
+                        "fq_address": "A.0x7deafdfc288e422d.BloctoPass",
+                        "pin": "3c7796c792dc130c2e565c8246de8a8d5add43e7f340efe20c52568c43602b36",
+                        "pin_block_height": 139076585
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "index": {
+                "index": 1,
+                "type": "Int",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/bltstaking-stake-unstaked-blt.json
+++ b/templates/Blocto/bltstaking-stake-unstaked-blt.json
@@ -1,0 +1,49 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "8ed0362d0804aa5c71dba2cf678487a7b33c869ae8cf33cc2eef9fe6618ca7b4",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "BltStaking Stake unstaked blt"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Request to re-stake unstaked tokens: {amount} BLT",
+                    "zh-CN": "请求重新质押解除质押的代币: {amount} BLT 代币",
+                    "zh-TW": "請求重新質押解除質押的代幣: {amount} BLT 代幣"
+                }
+            }
+        },
+        "cadence": "import BloctoPass from 0xBLOCTO_PASS_ADDRESS\n\ntransaction(amount: UFix64, index: Int) {\n  // The private reference to user's BloctoPass\n  let bloctoPassRef: &BloctoPass.NFT\n\n  prepare(account: AuthAccount) {\n    // Get a reference to the account's BloctoPass\n    let bloctoPassCollectionRef = account.borrow<&BloctoPass.Collection>(from: /storage/bloctoPassCollection)\n      ?? panic(\"Could not borrow reference to the owner's BloctoPass collection!\")\n\n    let ids = bloctoPassCollectionRef.getIDs()\n\n    // Get a reference to the BloctoPass\n    self.bloctoPassRef = bloctoPassCollectionRef.borrowBloctoPassPrivate(id: ids[index])\n  }\n\n  execute {\n    self.bloctoPassRef.stakeUnstakedTokens(amount: amount)\n  }\n}",
+        "dependencies": {
+            "0xBLOCTO_PASS_ADDRESS": {
+                "BloctoPass": {
+                    "testnet": {
+                        "address": "0x7deafdfc288e422d",
+                        "contract": "BloctoPass",
+                        "fq_address": "A.0x7deafdfc288e422d.BloctoPass",
+                        "pin": "3c7796c792dc130c2e565c8246de8a8d5add43e7f340efe20c52568c43602b36",
+                        "pin_block_height": 139076517
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "index": {
+                "index": 1,
+                "type": "Int",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/domains-borrow-money-by-nft.json
+++ b/templates/Blocto/domains-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "47074056a0cccd037979292b26684d131b1ca49bcb3b6183d34bb7bbea040bb2",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Domains Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/fnsDomainCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138885921
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138885953
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138886019
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138886040
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/domains-cancel-borrow-money.json
+++ b/templates/Blocto/domains-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "50231d85923890a9ae6b3f5f68f6b8de9be7ce9cc5940433e41594de0d541602",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Domains Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/fnsDomainCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138885900
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138885970
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/domains-force-redeem.json
+++ b/templates/Blocto/domains-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "21e98ab2217e29339aa1be18439fa3bd56acdb38cd8d6b2622bc785dd24c56f1",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Domains Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/fnsDomainCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138885966
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138886024
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/domains-lend-money.json
+++ b/templates/Blocto/domains-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "a94dc60ad7cae883c3d1704221f86fa5e068dfe5f41fb4b66d138807ac555c4f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Domains Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138886024
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138886062
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/domains-repay.json
+++ b/templates/Blocto/domains-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "d6caff312f80cd816e8571a6c1fe94df94e7f67a183978a118df583423f3aacc",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Domains Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/fnsDomainCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138886000
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138886068
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138886123
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/enemymetal-buy-with-flow-nft-mint-new-account.json
+++ b/templates/Blocto/enemymetal-buy-with-flow-nft-mint-new-account.json
@@ -1,0 +1,77 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "c313d4ed6d89203514b485f7caf83d91ad25309281c189819d531a6e7204308f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "EnemyMetal Buy with flow nft mint new account"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Buy new nft mint for {flowAmount} FLOW and store in a new account",
+                    "zh-CN": "为 {flowAmount} FLOW 购买新的 nft mint 并存储在新帐户中",
+                    "zh-TW": "為 {flowAmount} FLOW 購買新的 nft mint 並存儲在新帳戶中"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport EnemyMetal from 0xENEMY_METAL_ADDRESS\n\npub fun trySetupFlow(acct: AuthAccount) {\n    // setup account to use flow tokens\n    if acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) == nil {\n        // Create a new flow Vault and put it in storage\n        acct.save(<-FlowToken.createEmptyVault(), to: /storage/flowTokenVault)\n        // Create a public capability to the Vault that only exposes\n        // the deposit function through the Receiver interface\n        acct.link<&FlowToken.Vault{FungibleToken.Receiver}>(\n            /public/flowTokenReceiver,\n            target: /storage/flowTokenVault\n        )\n        // Create a public capability to the Vault that only exposes\n        // the balance field through the Balance interface\n        acct.link<&FlowToken.Vault{FungibleToken.Balance}>(\n            /public/flowTokenBalance,\n            target: /storage/flowTokenVault\n        )\n    }\n}\n\npub fun trySetupNft(acct: AuthAccount) {\n    // setup account to receive nfts from enemymetal collection\n    if acct.borrow<&EnemyMetal.Collection>(from: EnemyMetal.CollectionStoragePath) == nil {\n        // Create a new empty collection\n        let collection <- EnemyMetal.createEmptyCollection()\n        // save it to the account\n        acct.save(<-collection, to: EnemyMetal.CollectionStoragePath)\n        // create a public capability for the collection\n        acct.link<&EnemyMetal.Collection{NonFungibleToken.CollectionPublic, EnemyMetal.EnemyMetalCollectionPublic}>(EnemyMetal.CollectionPublicPath as! CapabilityPath, target: EnemyMetal.CollectionStoragePath)\n    }\n}\n\npub fun createAccount(pubKeys: [String], payer: AuthAccount): AuthAccount {\n    let acct = AuthAccount(payer: payer)\n    for key in pubKeys {\n        acct.addPublicKey(key.decodeHex())\n    }\n    trySetupNft(acct: acct)\n    trySetupFlow(acct: acct)\n    return acct\n}\n\n// This transaction is for buying a NFT mint using flow tokens\ntransaction(flowAmount: UFix64, payees: [Address], payeesShares: [UFix64], recipientKeys: [String], metadataArray: [String], claimMetadatasArray: [[String]]) {\n\n    let minter: &EnemyMetal.NFTMinter\n    let recipient: AuthAccount\n    let buyerVault: &FlowToken.Vault{FungibleToken.Provider}\n    var nfts: [EnemyMetal.NFTData]\n\n    prepare(minter: AuthAccount, custodian: AuthAccount, buyer: AuthAccount) {\n        pre {\n            metadataArray.length == claimMetadatasArray.length : \"metadata array must be same size of claim metadatas array\"\n            payees.length > 0 : \"need to provide atleast one payee\"\n            payees.length == payeesShares.length : \"need to define each payee share\"\n            recipientKeys.length > 0 : \"need to define atleast one public key\"\n        }\n\n        self.recipient = createAccount(pubKeys: recipientKeys, payer: custodian)\n\n        var x = 0\n        var sum = 0.0\n        while x < payeesShares.length {\n            sum = sum + payeesShares[x]\n            x = x + 1\n        }\n        if(sum < 1.0 || sum > 1.0) {\n            panic(\"payees shares need to be equal to 100%\")\n        }\n\n        // borrow a reference to the NFTMinter resource in storage\n        self.minter = minter.borrow<&EnemyMetal.NFTMinter>(from: EnemyMetal.MinterStoragePath)\n            ?? panic(\"Could not borrow a reference to the NFT minter\")\n\n        // build nfts data struct\n        self.nfts = [];\n        x = 0;\n        while x < metadataArray.length {\n            var claims: [EnemyMetal.NFTData] = [];\n            var currClaims: [String] = claimMetadatasArray[x];\n            var y = 0;\n            while y < currClaims.length {\n                claims.append(EnemyMetal.NFTData(metadata: currClaims[y], claims: []));\n                y = y + 1;\n            }\n            self.nfts.append(EnemyMetal.NFTData(metadata: metadataArray[x], claims: claims));\n            x = x + 1;\n        }\n\n        self.buyerVault = buyer.borrow<&FlowToken.Vault{FungibleToken.Provider}>(from: /storage/flowTokenVault)!\n    }\n\n    execute {\n        // deposit tokens to payees\n        var x = 0\n        while x < payees.length {\n            let payeeCap = getAccount(payees[x]).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            if let vaultRef = payeeCap.borrow() {\n                vaultRef.deposit(from: <-self.buyerVault.withdraw(amount: UFix64(flowAmount * payeesShares[x])))\n            } else {\n                panic(\"couldn't get payee vault ref\")\n            }\n            x = x + 1\n        }\n\n        // Borrow the recipient's public NFT collection reference\n        let receiver = self.recipient\n            .getCapability(EnemyMetal.CollectionPublicPath)!\n            .borrow<&{NonFungibleToken.CollectionPublic}>()\n            ?? panic(\"Could not get receiver reference to the NFT Collection\")\n\n        x = 0;\n        while x < self.nfts.length {\n            // Mint the NFT and deposit it to the recipient's collection\n            self.minter.mintNFT(recipient: receiver, data: self.nfts[x]);\n            x = x + 1;\n        }\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075597
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075632
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075682
+                    }
+                }
+            },
+            "0xENEMY_METAL_ADDRESS": {
+                "EnemyMetal": {
+                    "testnet": {
+                        "address": "0x244f523a150d41c1",
+                        "contract": "EnemyMetal",
+                        "fq_address": "A.0x244f523a150d41c1.EnemyMetal",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 139075770
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "acct": {
+                "index": 0,
+                "type": "AuthAccount",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/enemymetal-buy-with-flow-nft-new-account.json
+++ b/templates/Blocto/enemymetal-buy-with-flow-nft-new-account.json
@@ -1,0 +1,77 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "46c2d663efc66cbd2056ebe074d33c1edb7956c14df8804d245055342ba07181",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "EnemyMetal Buy with flow nft new account"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Buy nft {nft_id} for {flowAmount} FLOW and store in a new account",
+                    "zh-CN": "为 {flowAmount} FLOW 购买 nft {nft_id} 并存储在新帐户中",
+                    "zh-TW": "為 {flowAmount} FLOW 購買 nft {nft_id} 並存儲在新帳戶中"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport EnemyMetal from 0xENEMY_METAL_ADDRESS\n\npub fun trySetupFlow(acct: AuthAccount) {\n    // setup account to use flow tokens\n    if acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) == nil {\n        // Create a new flow Vault and put it in storage\n        acct.save(<-FlowToken.createEmptyVault(), to: /storage/flowTokenVault)\n        // Create a public capability to the Vault that only exposes\n        // the deposit function through the Receiver interface\n        acct.link<&FlowToken.Vault{FungibleToken.Receiver}>(\n            /public/flowTokenReceiver,\n            target: /storage/flowTokenVault\n        )\n        // Create a public capability to the Vault that only exposes\n        // the balance field through the Balance interface\n        acct.link<&FlowToken.Vault{FungibleToken.Balance}>(\n            /public/flowTokenBalance,\n            target: /storage/flowTokenVault\n        )\n    }\n}\n\npub fun trySetupNft(acct: AuthAccount) {\n    // setup account to receive nfts from enemymetal collection\n    if acct.borrow<&EnemyMetal.Collection>(from: EnemyMetal.CollectionStoragePath) == nil {\n        // Create a new empty collection\n        let collection <- EnemyMetal.createEmptyCollection()\n        // save it to the account\n        acct.save(<-collection, to: EnemyMetal.CollectionStoragePath)\n        // create a public capability for the collection\n        acct.link<&EnemyMetal.Collection{NonFungibleToken.CollectionPublic, EnemyMetal.EnemyMetalCollectionPublic}>(EnemyMetal.CollectionPublicPath as! CapabilityPath, target: EnemyMetal.CollectionStoragePath)\n    }\n}\n\npub fun createAccount(pubKeys: [String], payer: AuthAccount): AuthAccount {\n    let acct = AuthAccount(payer: payer)\n    for key in pubKeys {\n        acct.addPublicKey(key.decodeHex())\n    }\n    trySetupNft(acct: acct)\n    trySetupFlow(acct: acct)\n    return acct\n}\n\n// This transaction is for buying a NFT using flow tokens to a recipient account\ntransaction(flowAmount: UFix64, payees: [Address], payeesShares: [UFix64], recipientKeys: [String], nft_id: UInt64) {\n\n    let sellerCollectionRef: &EnemyMetal.Collection\n    let buyerVault: &FlowToken.Vault{FungibleToken.Provider}\n    let recipient: AuthAccount\n\n    prepare(seller: AuthAccount, custodian: AuthAccount, buyer: AuthAccount) {\n        pre {\n            payees.length > 0 : \"need to provide atleast one payee\"\n            payees.length == payeesShares.length : \"need to define each payee share\"\n            recipientKeys.length > 0 : \"need to define atleast one public key\"\n        }\n\n        self.recipient = createAccount(pubKeys: recipientKeys, payer: custodian)\n\n        var x = 0\n        var sum = 0.0\n        while x < payeesShares.length {\n            sum = sum + payeesShares[x]\n            x = x + 1\n        }\n        if(sum < 1.0 || sum > 1.0) {\n            panic(\"payees shares need to be equal to 100%\")\n        }\n\n        self.buyerVault = buyer.borrow<&FlowToken.Vault{FungibleToken.Provider}>(from: /storage/flowTokenVault)!\n\n        // borrow a reference to the sellers NFT collection\n        self.sellerCollectionRef = seller.borrow<&EnemyMetal.Collection>(from: EnemyMetal.CollectionStoragePath)\n            ?? panic(\"Could not borrow a reference to the seller's collection\")\n    }\n\n    execute {\n        // deposit tokens to payees\n        var x = 0\n        while x < payees.length {\n            let payeeCap = getAccount(payees[x]).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            if let vaultRef = payeeCap.borrow() {\n                vaultRef.deposit(from: <-self.buyerVault.withdraw(amount: UFix64(flowAmount * payeesShares[x])))\n            } else {\n                panic(\"couldn't get payee vault ref\")\n            }\n            x = x + 1\n        }\n\n        // withdraw the NFT from the owner's collection\n        let nft <- self.sellerCollectionRef.withdraw(withdrawID: nft_id)\n\n        // borrow a public reference to the receivers collection\n        let depositRef = self.recipient.getCapability(EnemyMetal.CollectionPublicPath)!.borrow<&{NonFungibleToken.CollectionPublic}>()!\n\n        // Deposit the NFT in the recipient's collection\n        depositRef.deposit(token: <-nft)\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075540
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075554
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075601
+                    }
+                }
+            },
+            "0xENEMY_METAL_ADDRESS": {
+                "EnemyMetal": {
+                    "testnet": {
+                        "address": "0x244f523a150d41c1",
+                        "contract": "EnemyMetal",
+                        "fq_address": "A.0x244f523a150d41c1.EnemyMetal",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 139075717
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "acct": {
+                "index": 0,
+                "type": "AuthAccount",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/enemymetal-buy-with-flow-nft.json
+++ b/templates/Blocto/enemymetal-buy-with-flow-nft.json
@@ -1,0 +1,97 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "5a4b2b88f0ef47a81fdd22de1781d7dd3e370a756a42daa4a2a7be4a4639b251",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "EnemyMetal Buy with flow nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Buy nft {nft_id} for {flowAmount} FLOW and store in {recipient}",
+                    "zh-CN": "为 {flowAmount} FLOW 购买 nft {nft_id} 并存储在 {recipient}",
+                    "zh-TW": "為 {flowAmount} FLOW 購買 nft {nft_id} 並存儲在 {recipient}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport EnemyMetal from 0xENEMY_METAL_ADDRESS\n\n// This transaction is for buying a NFT using flow tokens to a recipient account\ntransaction(flowAmount: UFix64, payees: [Address], payeesShares: [UFix64], recipient: Address, nft_id: UInt64) {\n\n    let sellerCollectionRef: &EnemyMetal.Collection\n    let buyerVault: &FlowToken.Vault{FungibleToken.Provider}\n\n    prepare(seller: AuthAccount, buyer: AuthAccount) {\n        pre {\n            payees.length > 0 : \"need to provide atleast one payee\"\n            payees.length == payeesShares.length : \"need to define each payee share\"\n        }\n\n        var x = 0\n        var sum = 0.0\n        while x < payeesShares.length {\n            sum = sum + payeesShares[x]\n            x = x + 1\n        }\n        if(sum < 1.0 || sum > 1.0) {\n            panic(\"payees shares need to be equal to 100%\")\n        }\n\n        self.buyerVault = buyer.borrow<&FlowToken.Vault{FungibleToken.Provider}>(from: /storage/flowTokenVault)!\n\n        // borrow a reference to the sellers NFT collection\n        self.sellerCollectionRef = seller.borrow<&EnemyMetal.Collection>(from: EnemyMetal.CollectionStoragePath)\n            ?? panic(\"Could not borrow a reference to the seller's collection\")\n    }\n\n    execute {\n        // deposit tokens to payees\n        var x = 0\n        while x < payees.length {\n            let payeeCap = getAccount(payees[x]).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            if let vaultRef = payeeCap.borrow() {\n                vaultRef.deposit(from: <-self.buyerVault.withdraw(amount: UFix64(flowAmount * payeesShares[x])))\n            } else {\n                panic(\"couldn't get payee vault ref\")\n            }\n            x = x + 1\n        }\n\n        // Get the public account object for the recipient\n        let recipient = getAccount(recipient)\n\n        // withdraw the NFT from the owner's collection\n        let nft <- self.sellerCollectionRef.withdraw(withdrawID: nft_id)\n\n        // borrow a public reference to the receivers collection\n        let depositRef = recipient.getCapability(EnemyMetal.CollectionPublicPath)!.borrow<&{NonFungibleToken.CollectionPublic}>()!\n\n        // Deposit the NFT in the recipient's collection\n        depositRef.deposit(token: <-nft)\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075532
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075554
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075597
+                    }
+                }
+            },
+            "0xENEMY_METAL_ADDRESS": {
+                "EnemyMetal": {
+                    "testnet": {
+                        "address": "0x244f523a150d41c1",
+                        "contract": "EnemyMetal",
+                        "fq_address": "A.0x244f523a150d41c1.EnemyMetal",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 139075693
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "flowAmount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "payees": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "payeesShares": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "recipient": {
+                "index": 3,
+                "type": "Address",
+                "messages": {}
+            },
+            "nft_id": {
+                "index": 4,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/enemymetal-deposit-nft.json
+++ b/templates/Blocto/enemymetal-deposit-nft.json
@@ -1,0 +1,80 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "9102ae220d17dbe9f5fdbd0c1980d39b8cc76fdb57974b465637dc1917db092b",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "EnemyMetal Deposit nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Desposit nft(s) into a safe account"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport EnemyMetal from 0xENEMY_METAL_ADDRESS\n\n// This transaction is for depositing a NFT into safe account\ntransaction(nftIds: [UInt64], userSafeRecipient: Address) {\n\n    let userCollectionRef: &EnemyMetal.Collection\n    prepare(user: AuthAccount) {\n        // borrow a reference to the safe NFT collection\n        self.userCollectionRef = user.borrow<&EnemyMetal.Collection>(from: EnemyMetal.CollectionStoragePath)\n            ?? panic(\"Could not borrow a reference to the user's collection\")\n    }\n\n    execute {\n        // Get the public account object for the user safe recipient\n        let recipient = getAccount(userSafeRecipient)\n\n        // borrow a public reference to the receivers collection\n        let depositRef = recipient.getCapability(EnemyMetal.CollectionPublicPath)!.borrow<&{NonFungibleToken.CollectionPublic}>()!\n\n        var x = 0;\n        // transfer NFT(s) to recipient\n        while x < nftIds.length {\n            // withdraw the NFT from the owner's collection\n            let nft <- self.userCollectionRef.withdraw(withdrawID: nftIds[x])\n\n            // Deposit the NFT in the recipient's collection\n            depositRef.deposit(token: <-nft)\n            x = x + 1;\n        }\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075749
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075784
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075815
+                    }
+                }
+            },
+            "0xENEMY_METAL_ADDRESS": {
+                "EnemyMetal": {
+                    "testnet": {
+                        "address": "0x244f523a150d41c1",
+                        "contract": "EnemyMetal",
+                        "fq_address": "A.0x244f523a150d41c1.EnemyMetal",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 139075881
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "nftIds": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "userSafeRecipient": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/enemymetal-withdraw-nft.json
+++ b/templates/Blocto/enemymetal-withdraw-nft.json
@@ -1,0 +1,75 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "72387be8086f1c990ef0a74258c46b99c45047c674e7478d1d094011eaf2c3d8",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "EnemyMetal Withdraw nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Withdraw nft(s) and pay a flow fee"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport EnemyMetal from 0xENEMY_METAL_ADDRESS\n\npub fun trySetupNft(acct: AuthAccount) {\n    // setup account to receive nfts from EnemyMetal collection\n    if acct.borrow<&EnemyMetal.Collection>(from: EnemyMetal.CollectionStoragePath) == nil {\n        // Create a new empty collection\n        let collection <- EnemyMetal.createEmptyCollection()\n        // save it to the account\n        acct.save(<-collection, to: EnemyMetal.CollectionStoragePath)\n        // create a public capability for the collection\n        acct.link<&EnemyMetal.Collection{NonFungibleToken.CollectionPublic, EnemyMetal.EnemyMetalCollectionPublic}>(EnemyMetal.CollectionPublicPath as! CapabilityPath, target: EnemyMetal.CollectionStoragePath)\n    }\n}\n\n// This transaction is for withdrawing a NFT and charging a flow fee\ntransaction(nftIds: [UInt64], feeflowAmount: UFix64, payee: Address) {\n\n    let userCollectionRef: &EnemyMetal.Collection\n    let payer: AuthAccount\n\n    prepare(user: AuthAccount, payer: AuthAccount) {\n\n        // borrow a reference to the safe NFT collection\n        self.userCollectionRef = user.borrow<&EnemyMetal.Collection>(from: EnemyMetal.CollectionStoragePath)\n            ?? panic(\"Could not borrow a reference to the user's collection\")\n\n        // try setup nft collection for payer\n        trySetupNft(acct: payer)\n\n        self.payer = payer;\n    }\n\n    execute {\n        // borrow a reference to payers Flow vault\n        let payerVault = self.payer.borrow<&FlowToken.Vault{FungibleToken.Provider}>(from: /storage/flowTokenVault)!\n\n        // deposit tokens to payee\n        if feeflowAmount > 0.0 {\n            let payeeCap = getAccount(payee).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            if let vaultRef = payeeCap.borrow() {\n                vaultRef.deposit(from: <-payerVault.withdraw(amount: UFix64(feeflowAmount)))\n            } else {\n                panic(\"couldn't get payee vault ref\")\n            }\n        }\n\n        // borrow a public reference to the payer collection\n        let depositRef = self.payer.getCapability(EnemyMetal.CollectionPublicPath)!.borrow<&{NonFungibleToken.CollectionPublic}>()!\n\n        var x = 0;\n        // transfer NFT(s) to recipient\n        while x < nftIds.length {\n            // withdraw the NFT from the owner's collection\n            let nft <- self.userCollectionRef.withdraw(withdrawID: nftIds[x])\n\n            // Deposit the NFT in the recipient's collection\n            depositRef.deposit(token: <-nft)\n            x = x + 1;\n        }\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075749
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139075784
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139075815
+                    }
+                }
+            },
+            "0xENEMY_METAL_ADDRESS": {
+                "EnemyMetal": {
+                    "testnet": {
+                        "address": "0x244f523a150d41c1",
+                        "contract": "EnemyMetal",
+                        "fq_address": "A.0x244f523a150d41c1.EnemyMetal",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 139075881
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "acct": {
+                "index": 0,
+                "type": "AuthAccount",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/epix-buy-with-flow-nft-mint-new-account.json
+++ b/templates/Blocto/epix-buy-with-flow-nft-mint-new-account.json
@@ -1,0 +1,77 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "483677b292efe3cd17b628d6f2f0e99a66e353345236f6137dc8a410aa3fba77",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Epix Buy with flow nft mint new account"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Buy new nft mint for {flowAmount} FLOW and store in a new account",
+                    "zh-CN": "为 {flowAmount} FLOW 购买新的 nft mint 并存储在新帐户中",
+                    "zh-TW": "為 {flowAmount} FLOW 購買新的 nft mint 並存儲在新帳戶中"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport Epix from 0xEPIX_ADDRESS\n\npub fun trySetupFlow(acct: AuthAccount) {\n    // setup account to use flow tokens\n    if acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) == nil {\n        // Create a new flow Vault and put it in storage\n        acct.save(<-FlowToken.createEmptyVault(), to: /storage/flowTokenVault)\n        // Create a public capability to the Vault that only exposes\n        // the deposit function through the Receiver interface\n        acct.link<&FlowToken.Vault{FungibleToken.Receiver}>(\n            /public/flowTokenReceiver,\n            target: /storage/flowTokenVault\n        )\n        // Create a public capability to the Vault that only exposes\n        // the balance field through the Balance interface\n        acct.link<&FlowToken.Vault{FungibleToken.Balance}>(\n            /public/flowTokenBalance,\n            target: /storage/flowTokenVault\n        )\n    }\n}\n\npub fun trySetupNft(acct: AuthAccount) {\n    // setup account to receive nfts from epix collection\n    if acct.borrow<&Epix.Collection>(from: Epix.CollectionStoragePath) == nil {\n        // Create a new empty collection\n        let collection <- Epix.createEmptyCollection()\n        // save it to the account\n        acct.save(<-collection, to: Epix.CollectionStoragePath)\n        // create a public capability for the collection\n        acct.link<&Epix.Collection{NonFungibleToken.CollectionPublic, Epix.EpixCollectionPublic}>(Epix.CollectionPublicPath as! CapabilityPath, target: Epix.CollectionStoragePath)\n    }\n}\n\npub fun createAccount(pubKeys: [String], payer: AuthAccount): AuthAccount {\n    let acct = AuthAccount(payer: payer)\n    for key in pubKeys {\n        acct.addPublicKey(key.decodeHex())\n    }\n    trySetupNft(acct: acct)\n    trySetupFlow(acct: acct)\n    return acct\n}\n\n// This transaction is for buying a NFT mint using flow tokens\ntransaction(flowAmount: UFix64, payees: [Address], payeesShares: [UFix64], recipientKeys: [String], metadataArray: [String], claimMetadatasArray: [[String]]) {\n\n    let minter: &Epix.NFTMinter\n    let recipient: AuthAccount\n    let buyerVault: &FlowToken.Vault{FungibleToken.Provider}\n    var nfts: [Epix.NFTData]\n\n    prepare(minter: AuthAccount, custodian: AuthAccount, buyer: AuthAccount) {\n        pre {\n            metadataArray.length == claimMetadatasArray.length : \"metadata array must be same size of claim metadatas array\"\n            payees.length > 0 : \"need to provide atleast one payee\"\n            payees.length == payeesShares.length : \"need to define each payee share\"\n            recipientKeys.length > 0 : \"need to define atleast one public key\"\n        }\n\n        self.recipient = createAccount(pubKeys: recipientKeys, payer: custodian)\n\n        var x = 0\n        var sum = 0.0\n        while x < payeesShares.length {\n            sum = sum + payeesShares[x]\n            x = x + 1\n        }\n        if(sum < 1.0 || sum > 1.0) {\n            panic(\"payees shares need to be equal to 100%\")\n        }\n\n        // borrow a reference to the NFTMinter resource in storage\n        self.minter = minter.borrow<&Epix.NFTMinter>(from: Epix.MinterStoragePath)\n            ?? panic(\"Could not borrow a reference to the NFT minter\")\n\n        // build nfts data struct\n        self.nfts = [];\n        x = 0;\n        while x < metadataArray.length {\n            var claims: [Epix.NFTData] = [];\n            var currClaims: [String] = claimMetadatasArray[x];\n            var y = 0;\n            while y < currClaims.length {\n                claims.append(Epix.NFTData(metadata: currClaims[y], claims: []));\n                y = y + 1;\n            }\n            self.nfts.append(Epix.NFTData(metadata: metadataArray[x], claims: claims));\n            x = x + 1;\n        }\n\n        self.buyerVault = buyer.borrow<&FlowToken.Vault{FungibleToken.Provider}>(from: /storage/flowTokenVault)!\n    }\n\n    execute {\n        // deposit tokens to payees\n        var x = 0\n        while x < payees.length {\n            let payeeCap = getAccount(payees[x]).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            if let vaultRef = payeeCap.borrow() {\n                vaultRef.deposit(from: <-self.buyerVault.withdraw(amount: UFix64(flowAmount * payeesShares[x])))\n            } else {\n                panic(\"couldn't get payee vault ref\")\n            }\n            x = x + 1\n        }\n\n        // Borrow the recipient's public NFT collection reference\n        let receiver = self.recipient\n            .getCapability(Epix.CollectionPublicPath)!\n            .borrow<&{NonFungibleToken.CollectionPublic}>()\n            ?? panic(\"Could not get receiver reference to the NFT Collection\")\n\n        x = 0;\n        while x < self.nfts.length {\n            // Mint the NFT and deposit it to the recipient's collection\n            self.minter.mintNFT(recipient: receiver, data: self.nfts[x]);\n            x = x + 1;\n        }\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076506
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076537
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076575
+                    }
+                }
+            },
+            "0xEPIX_ADDRESS": {
+                "Epix": {
+                    "testnet": {
+                        "address": "0x244f523a150d41c1",
+                        "contract": "Epix",
+                        "fq_address": "A.0x244f523a150d41c1.Epix",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 139076658
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "acct": {
+                "index": 0,
+                "type": "AuthAccount",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/epix-buy-with-flow-nft-new-account.json
+++ b/templates/Blocto/epix-buy-with-flow-nft-new-account.json
@@ -1,0 +1,77 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "455a38bcc9c315d266b2c5933f6da72bdea3abff240d83541961e3b928a912af",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Epix Buy with flow nft new account"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Buy nft {nft_id} for {flowAmount} FLOW and store in a new account",
+                    "zh-CN": "为 {flowAmount} FLOW 购买 nft {nft_id} 并存储在新帐户中",
+                    "zh-TW": "為 {flowAmount} FLOW 購買 nft {nft_id} 並存儲在新帳戶中"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport Epix from 0xEPIX_ADDRESS\n\npub fun trySetupFlow(acct: AuthAccount) {\n    // setup account to use flow tokens\n    if acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) == nil {\n        // Create a new flow Vault and put it in storage\n        acct.save(<-FlowToken.createEmptyVault(), to: /storage/flowTokenVault)\n        // Create a public capability to the Vault that only exposes\n        // the deposit function through the Receiver interface\n        acct.link<&FlowToken.Vault{FungibleToken.Receiver}>(\n            /public/flowTokenReceiver,\n            target: /storage/flowTokenVault\n        )\n        // Create a public capability to the Vault that only exposes\n        // the balance field through the Balance interface\n        acct.link<&FlowToken.Vault{FungibleToken.Balance}>(\n            /public/flowTokenBalance,\n            target: /storage/flowTokenVault\n        )\n    }\n}\n\npub fun trySetupNft(acct: AuthAccount) {\n    // setup account to receive nfts from epix collection\n    if acct.borrow<&Epix.Collection>(from: Epix.CollectionStoragePath) == nil {\n        // Create a new empty collection\n        let collection <- Epix.createEmptyCollection()\n        // save it to the account\n        acct.save(<-collection, to: Epix.CollectionStoragePath)\n        // create a public capability for the collection\n        acct.link<&Epix.Collection{NonFungibleToken.CollectionPublic, Epix.EpixCollectionPublic}>(Epix.CollectionPublicPath as! CapabilityPath, target: Epix.CollectionStoragePath)\n    }\n}\n\npub fun createAccount(pubKeys: [String], payer: AuthAccount): AuthAccount {\n    let acct = AuthAccount(payer: payer)\n    for key in pubKeys {\n        acct.addPublicKey(key.decodeHex())\n    }\n    trySetupNft(acct: acct)\n    trySetupFlow(acct: acct)\n    return acct\n}\n\n// This transaction is for buying a NFT using flow tokens to a recipient account\ntransaction(flowAmount: UFix64, payees: [Address], payeesShares: [UFix64], recipientKeys: [String], nft_id: UInt64) {\n\n    let sellerCollectionRef: &Epix.Collection\n    let buyerVault: &FlowToken.Vault{FungibleToken.Provider}\n    let recipient: AuthAccount\n\n    prepare(seller: AuthAccount, custodian: AuthAccount, buyer: AuthAccount) {\n        pre {\n            payees.length > 0 : \"need to provide atleast one payee\"\n            payees.length == payeesShares.length : \"need to define each payee share\"\n            recipientKeys.length > 0 : \"need to define atleast one public key\"\n        }\n\n        self.recipient = createAccount(pubKeys: recipientKeys, payer: custodian)\n\n        var x = 0\n        var sum = 0.0\n        while x < payeesShares.length {\n            sum = sum + payeesShares[x]\n            x = x + 1\n        }\n        if(sum < 1.0 || sum > 1.0) {\n            panic(\"payees shares need to be equal to 100%\")\n        }\n\n        self.buyerVault = buyer.borrow<&FlowToken.Vault{FungibleToken.Provider}>(from: /storage/flowTokenVault)!\n\n        // borrow a reference to the sellers NFT collection\n        self.sellerCollectionRef = seller.borrow<&Epix.Collection>(from: Epix.CollectionStoragePath)\n            ?? panic(\"Could not borrow a reference to the seller's collection\")\n    }\n\n    execute {\n        // deposit tokens to payees\n        var x = 0\n        while x < payees.length {\n            let payeeCap = getAccount(payees[x]).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            if let vaultRef = payeeCap.borrow() {\n                vaultRef.deposit(from: <-self.buyerVault.withdraw(amount: UFix64(flowAmount * payeesShares[x])))\n            } else {\n                panic(\"couldn't get payee vault ref\")\n            }\n            x = x + 1\n        }\n\n        // withdraw the NFT from the owner's collection\n        let nft <- self.sellerCollectionRef.withdraw(withdrawID: nft_id)\n\n        // borrow a public reference to the receivers collection\n        let depositRef = self.recipient.getCapability(Epix.CollectionPublicPath)!.borrow<&{NonFungibleToken.CollectionPublic}>()!\n\n        // Deposit the NFT in the recipient's collection\n        depositRef.deposit(token: <-nft)\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076561
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076600
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076637
+                    }
+                }
+            },
+            "0xEPIX_ADDRESS": {
+                "Epix": {
+                    "testnet": {
+                        "address": "0x244f523a150d41c1",
+                        "contract": "Epix",
+                        "fq_address": "A.0x244f523a150d41c1.Epix",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 139076744
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "acct": {
+                "index": 0,
+                "type": "AuthAccount",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/epix-buy-with-flow-nft.json
+++ b/templates/Blocto/epix-buy-with-flow-nft.json
@@ -1,0 +1,97 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "0a5203cc0f52bce96541c6620ba25a50fe3237dd580798fca187d3bead54f617",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Epix Buy with flow nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Buy nft {nft_id} for {flowAmount} FLOW and store in {recipient}",
+                    "zh-CN": "为 {flowAmount} FLOW 购买 nft {nft_id} 并存储在 {recipient}",
+                    "zh-TW": "為 {flowAmount} FLOW 購買 nft {nft_id} 並存儲在 {recipient}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport Epix from 0xEPIX_ADDRESS\n\n// This transaction is for buying a NFT using flow tokens to a recipient account\ntransaction(flowAmount: UFix64, payees: [Address], payeesShares: [UFix64], recipient: Address, nft_id: UInt64) {\n\n    let sellerCollectionRef: &Epix.Collection\n    let buyerVault: &FlowToken.Vault{FungibleToken.Provider}\n\n    prepare(seller: AuthAccount, buyer: AuthAccount) {\n        pre {\n            payees.length > 0 : \"need to provide atleast one payee\"\n            payees.length == payeesShares.length : \"need to define each payee share\"\n        }\n\n        var x = 0\n        var sum = 0.0\n        while x < payeesShares.length {\n            sum = sum + payeesShares[x]\n            x = x + 1\n        }\n        if(sum < 1.0 || sum > 1.0) {\n            panic(\"payees shares need to be equal to 100%\")\n        }\n\n        self.buyerVault = buyer.borrow<&FlowToken.Vault{FungibleToken.Provider}>(from: /storage/flowTokenVault)!\n\n        // borrow a reference to the sellers NFT collection\n        self.sellerCollectionRef = seller.borrow<&Epix.Collection>(from: Epix.CollectionStoragePath)\n            ?? panic(\"Could not borrow a reference to the seller's collection\")\n    }\n\n    execute {\n        // deposit tokens to payees\n        var x = 0\n        while x < payees.length {\n            let payeeCap = getAccount(payees[x]).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            if let vaultRef = payeeCap.borrow() {\n                vaultRef.deposit(from: <-self.buyerVault.withdraw(amount: UFix64(flowAmount * payeesShares[x])))\n            } else {\n                panic(\"couldn't get payee vault ref\")\n            }\n            x = x + 1\n        }\n\n        // Get the public account object for the recipient\n        let recipient = getAccount(recipient)\n\n        // withdraw the NFT from the owner's collection\n        let nft <- self.sellerCollectionRef.withdraw(withdrawID: nft_id)\n\n        // borrow a public reference to the receivers collection\n        let depositRef = recipient.getCapability(Epix.CollectionPublicPath)!.borrow<&{NonFungibleToken.CollectionPublic}>()!\n\n        // Deposit the NFT in the recipient's collection\n        depositRef.deposit(token: <-nft)\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076441
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076481
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076506
+                    }
+                }
+            },
+            "0xEPIX_ADDRESS": {
+                "Epix": {
+                    "testnet": {
+                        "address": "0x244f523a150d41c1",
+                        "contract": "Epix",
+                        "fq_address": "A.0x244f523a150d41c1.Epix",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 139076585
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "flowAmount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "payees": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "payeesShares": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "recipient": {
+                "index": 3,
+                "type": "Address",
+                "messages": {}
+            },
+            "nft_id": {
+                "index": 4,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/epix-deposit-nft.json
+++ b/templates/Blocto/epix-deposit-nft.json
@@ -1,0 +1,80 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "eb601fe0a39aff50a3dfd70591ecb7356ca435c1abd04815cffcb384ecea609f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Epix Deposit nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Desposit nft(s) into a safe account"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport Epix from 0xEPIX_ADDRESS\n\n// This transaction is for depositing a NFT into safe account\ntransaction(nftIds: [UInt64], userSafeRecipient: Address) {\n\n    let userCollectionRef: &Epix.Collection\n    prepare(user: AuthAccount) {\n        // borrow a reference to the safe NFT collection\n        self.userCollectionRef = user.borrow<&Epix.Collection>(from: Epix.CollectionStoragePath)\n            ?? panic(\"Could not borrow a reference to the user's collection\")\n    }\n\n    execute {\n        // Get the public account object for the user safe recipient\n        let recipient = getAccount(userSafeRecipient)\n\n        // borrow a public reference to the receivers collection\n        let depositRef = recipient.getCapability(Epix.CollectionPublicPath)!.borrow<&{NonFungibleToken.CollectionPublic}>()!\n\n        var x = 0;\n        // transfer NFT(s) to recipient\n        while x < nftIds.length {\n            // withdraw the NFT from the owner's collection\n            let nft <- self.userCollectionRef.withdraw(withdrawID: nftIds[x])\n\n            // Deposit the NFT in the recipient's collection\n            depositRef.deposit(token: <-nft)\n            x = x + 1;\n        }\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076619
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076658
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076703
+                    }
+                }
+            },
+            "0xEPIX_ADDRESS": {
+                "Epix": {
+                    "testnet": {
+                        "address": "0x244f523a150d41c1",
+                        "contract": "Epix",
+                        "fq_address": "A.0x244f523a150d41c1.Epix",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 139076797
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "nftIds": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "userSafeRecipient": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/epix-withdraw-nft.json
+++ b/templates/Blocto/epix-withdraw-nft.json
@@ -1,0 +1,75 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ae4c0651ee0191491d9a062d99aa4fd5a702c98ba84c8cc38a035bb05436da14",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Epix Withdraw nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Withdraw nft(s) and pay a flow fee"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport Epix from 0xEPIX_ADDRESS\n\npub fun trySetupNft(acct: AuthAccount) {\n    // setup account to receive nfts from epix collection\n    if acct.borrow<&Epix.Collection>(from: Epix.CollectionStoragePath) == nil {\n        // Create a new empty collection\n        let collection <- Epix.createEmptyCollection()\n        // save it to the account\n        acct.save(<-collection, to: Epix.CollectionStoragePath)\n        // create a public capability for the collection\n        acct.link<&Epix.Collection{NonFungibleToken.CollectionPublic, Epix.EpixCollectionPublic}>(Epix.CollectionPublicPath as! CapabilityPath, target: Epix.CollectionStoragePath)\n    }\n}\n\n// This transaction is for withdrawing a NFT and charging a flow fee\ntransaction(nftIds: [UInt64], feeflowAmount: UFix64, payee: Address) {\n\n    let userCollectionRef: &Epix.Collection\n    let payer: AuthAccount\n\n    prepare(user: AuthAccount, payer: AuthAccount) {\n\n        // borrow a reference to the safe NFT collection\n        self.userCollectionRef = user.borrow<&Epix.Collection>(from: Epix.CollectionStoragePath)\n            ?? panic(\"Could not borrow a reference to the user's collection\")\n\n        // try setup nft collection for payer\n        trySetupNft(acct: payer)\n\n        self.payer = payer;\n    }\n\n    execute {\n        // borrow a reference to payers Flow vault\n        let payerVault = self.payer.borrow<&FlowToken.Vault{FungibleToken.Provider}>(from: /storage/flowTokenVault)!\n\n        // deposit tokens to payee\n        if feeflowAmount > 0.0 {\n            let payeeCap = getAccount(payee).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            if let vaultRef = payeeCap.borrow() {\n                vaultRef.deposit(from: <-payerVault.withdraw(amount: UFix64(feeflowAmount)))\n            } else {\n                panic(\"couldn't get payee vault ref\")\n            }\n        }\n\n        // borrow a public reference to the payer collection\n        let depositRef = self.payer.getCapability(Epix.CollectionPublicPath)!.borrow<&{NonFungibleToken.CollectionPublic}>()!\n\n        var x = 0;\n        // transfer NFT(s) to recipient\n        while x < nftIds.length {\n            // withdraw the NFT from the owner's collection\n            let nft <- self.userCollectionRef.withdraw(withdrawID: nftIds[x])\n\n            // Deposit the NFT in the recipient's collection\n            depositRef.deposit(token: <-nft)\n            x = x + 1;\n        }\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076623
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076663
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076742
+                    }
+                }
+            },
+            "0xEPIX_ADDRESS": {
+                "Epix": {
+                    "testnet": {
+                        "address": "0x244f523a150d41c1",
+                        "contract": "Epix",
+                        "fq_address": "A.0x244f523a150d41c1.Epix",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 139076809
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "acct": {
+                "index": 0,
+                "type": "AuthAccount",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/eternalmoment-borrow-money-by-nft.json
+++ b/templates/Blocto/eternalmoment-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ef5db51c2443ebad7ca33c9e4f2e4c49e3224b650cc1e083ad9ad045fcb5596c",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "EternalMoment Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/EternalMomentCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138886019
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138886038
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138886123
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138886154
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/eternalmoment-cancel-borrow-money.json
+++ b/templates/Blocto/eternalmoment-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "a554698611b1374ec03870ff1165bcdfff64382785678f8d82bdd377ec86bc11",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "EternalMoment Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/EternalMomentCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138886061
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138886144
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/eternalmoment-force-redeem.json
+++ b/templates/Blocto/eternalmoment-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "9c107840677d3754e6f4f76aab80cab8296776ec52bc316cf386b253941931db",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "EternalMoment Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/EternalMomentCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138886144
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138886206
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/eternalmoment-lend-money.json
+++ b/templates/Blocto/eternalmoment-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "e1ea81f5834356f76e0055d58073a489f73c800e6f3c36a7045a70432fe2de73",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "EternalMoment Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138886125
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138886154
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/eternalmoment-repay.json
+++ b/templates/Blocto/eternalmoment-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "592d0ed0fa90155ff149de08567f8f0f54e92cc58a8082a0ebe0219fad43e728",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "EternalMoment Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/EternalMomentCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138886086
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138886154
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138886195
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/eternalshard-cancel-borrow-money.json
+++ b/templates/Blocto/eternalshard-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "66a22af6ad661c66bab55be67d8c80d3d1718d9bfe5b0134b8003abfe9d93f2e",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "EternalShard Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/EternalShardCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138886176
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138886257
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/eternalshard-force-redeem.json
+++ b/templates/Blocto/eternalshard-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "9b608f6db46f40fa1505049a1a568a7176b41166029c309006089fa166dbfb74",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "EternalShard Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/EternalShardCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138886186
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138886267
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/evolution-borrow-money-by-nft.json
+++ b/templates/Blocto/evolution-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "002e4e2dac9612f97c165bae374bdb6334ef1ddb8975e29c143fa4fac91f3c2b",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Evolution Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/EvolutionCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138886273
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889094
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889117
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889122
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/evolution-force-redeem.json
+++ b/templates/Blocto/evolution-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "8653c150f29e5bce9838d51f631a177c92639dd9088cddaed1d628993e3aafec",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Evolution Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/EvolutionCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889148
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889230
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/evolution-lend-money.json
+++ b/templates/Blocto/evolution-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "6fd8ccc1dd2926c93fef764fd961f6824484fe7ac765c8bb56a5d1278d989ab2",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Evolution Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889216
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889236
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/evolution-repay.json
+++ b/templates/Blocto/evolution-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "aa56fc8d9c6b6d2abc629b1e3014058043f8f041c9834c6b5848ee4577f2dd91",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Evolution Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/EvolutionCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889148
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889230
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889264
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/fantastecnft-borrow-money-by-nft.json
+++ b/templates/Blocto/fantastecnft-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "dc00093f844ab44ff660850613133df1b010a75ebc360d3f17a33d9f9b9729f2",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FantastecNFT Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/FantastecNFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889678
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889719
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889784
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889835
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/fantastecnft-cancel-borrow-money.json
+++ b/templates/Blocto/fantastecnft-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "b3ef6855942115ca7565ced29d8a2dc3e2fce99472f30321b6f590b100ed60c0",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FantastecNFT Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/FantastecNFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889707
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889783
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/fantastecnft-force-redeem.json
+++ b/templates/Blocto/fantastecnft-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "8dc347bb079ed6eea127cd52e138b5853b3c826ae15adf93c1360a9a5eeaa4b8",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FantastecNFT Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/FantastecNFTCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889707
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889781
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/fantastecnft-lend-money.json
+++ b/templates/Blocto/fantastecnft-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "80e9ba7dc048289d84dbc36489bf877b5d08c76f098fc7c8a837a9bf77ee20fe",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FantastecNFT Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889783
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889807
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/fantastecnft-repay.json
+++ b/templates/Blocto/fantastecnft-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "552b16144b02e8ec84890ea6bf2efae5e3c91af55cf1603b38c4b240ce5af665",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FantastecNFT Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/FantastecNFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889793
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889868
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889905
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/fantop-sell_token.json
+++ b/templates/Blocto/fantop-sell_token.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "a7c35e6e78967ec6b421a968fbe8d5f357c7dc9b77a1e35e4e521b9b8500b2b5",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FanTop Sell_token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "List FanTop token.",
+                    "ja": "FanTopトークンを出品します"
+                }
+            }
+        },
+        "cadence": "import FanTopToken from 0xFANTOP_ADDRESS\nimport FanTopPermissionV2a from 0xFANTOP_ADDRESS\n\ntransaction(\n  agent: Address,\n  orderId: String,\n  refId: String,\n  nftId: UInt64,\n  version: UInt32,\n  metadata: [String],\n  signature: String,\n  keyIndex: Int\n) {\n  let capability: Capability<&FanTopToken.Collection>\n  let user: FanTopPermissionV2a.User\n\n  prepare(account: AuthAccount) {\n    self.user = FanTopPermissionV2a.User()\n    var capability = account.getCapability<&FanTopToken.Collection>(/private/FanTopTokenCollection)\n    if !capability.check() {\n      capability = account.link<&FanTopToken.Collection>(/private/FanTopTokenCollection, target:FanTopToken.collectionStoragePath) ?? panic(\"Link failed\")\n    }\n    self.capability = capability\n  }\n\n  execute {\n    self.user.sell(\n      agent: agent,\n      capability: self.capability,\n      orderId: orderId,\n      refId: refId,\n      nftId: nftId,\n      version: version,\n      metadata: metadata,\n      signature: signature.decodeHex(),\n      keyIndex: keyIndex\n    )\n  }\n}",
+        "dependencies": {
+            "0xFANTOP_ADDRESS": {
+                "FanTopPermissionV2a": {}
+            }
+        },
+        "arguments": {
+            "agent": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "orderId": {
+                "index": 1,
+                "type": "String",
+                "messages": {}
+            },
+            "refId": {
+                "index": 2,
+                "type": "String",
+                "messages": {}
+            },
+            "nftId": {
+                "index": 3,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "version": {
+                "index": 4,
+                "type": "UInt32",
+                "messages": {}
+            },
+            "metadata": {
+                "index": 5,
+                "type": "String",
+                "messages": {}
+            },
+            "signature": {
+                "index": 6,
+                "type": "String",
+                "messages": {}
+            },
+            "keyIndex": {
+                "index": 7,
+                "type": "Int",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/fantop-transfer_token.json
+++ b/templates/Blocto/fantop-transfer_token.json
@@ -1,0 +1,40 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "81bf77d49ef61c49ba4c483ee228504ee169fac9b320c3b0b56d91652a683deb",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FanTop Transfer_token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Transfer FanTop token.",
+                    "ja": "FanTopトークンをギフトします"
+                }
+            }
+        },
+        "cadence": "import FanTopToken from 0xFANTOP_ADDRESS\n\ntransaction(id: UInt64, to: Address) {\n  let transferToken: @FanTopToken.NFT\n\n  prepare(from: AuthAccount) {\n    let fromRef = from.borrow<&FanTopToken.Collection>(from: FanTopToken.collectionStoragePath)!\n    self.transferToken <- fromRef.withdraw(withdrawID: id) as! @FanTopToken.NFT\n  }\n\n  execute {\n    let toRef = getAccount(to).getCapability(FanTopToken.collectionPublicPath).borrow<&{FanTopToken.CollectionPublic}>()!\n    toRef.deposit(token: <- self.transferToken)\n  }\n}\n",
+        "dependencies": {
+            "0xFANTOP_ADDRESS": {
+                "FanTopToken": {}
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "to": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-bid-profile.json
+++ b/templates/Blocto/find-bid-profile.json
@@ -1,0 +1,69 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "9a1d98293998d1b1d16a15cf94e90138506c6863d93177b57a0cfd2ce9534b2e",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Bid profile"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Bid on a name {name} in FIND for {amount} FUSD"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\nimport FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport Profile from 0xFIND_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\n\ntransaction(name: String, amount: UFix64) {\n\tprepare(account: AuthAccount) {\n\n\n\t\t//Add exising FUSD or create a new one and add it\n\t\tlet fusdReceiver = account.getCapability<&{FungibleToken.Receiver}>(/public/fusdReceiver)\n\t\tif !fusdReceiver.check() {\n\t\t\tlet fusd <- FUSD.createEmptyVault()\n\t\t\taccount.save(<- fusd, to: /storage/fusdVault)\n\t\t\taccount.link<&FUSD.Vault{FungibleToken.Receiver}>( /public/fusdReceiver, target: /storage/fusdVault)\n\t\t\taccount.link<&FUSD.Vault{FungibleToken.Balance}>( /public/fusdBalance, target: /storage/fusdVault)\n\t\t}\n\n\t\tlet leaseCollection = account.getCapability<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>(FIND.LeasePublicPath)\n\t\tif !leaseCollection.check() {\n\t\t\taccount.unlink(FIND.LeasePublicPath)\n\t\t\tdestroy <- account.load<@AnyResource>(from:FIND.LeaseStoragePath)\n\n\t\t\taccount.save(<- FIND.createEmptyLeaseCollection(), to: FIND.LeaseStoragePath)\n\t\t\taccount.link<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>( FIND.LeasePublicPath, target: FIND.LeaseStoragePath)\n\t\t}\n\n\t\tlet bidCollection = account.getCapability<&FIND.BidCollection{FIND.BidCollectionPublic}>(FIND.BidPublicPath)\n\t\tif !bidCollection.check() {\n\t\t\taccount.unlink(FIND.BidPublicPath)\n\t\t\tdestroy <- account.load<@AnyResource>(from:FIND.BidStoragePath)\n\n\t\t\taccount.save(<- FIND.createEmptyBidCollection(receiver: fusdReceiver, leases: leaseCollection), to: FIND.BidStoragePath)\n\t\t\taccount.link<&FIND.BidCollection{FIND.BidCollectionPublic}>( FIND.BidPublicPath, target: FIND.BidStoragePath)\n\t\t}\n\n\t\tlet profileCap = account.getCapability<&{Profile.Public}>(Profile.publicPath)\n\t\tif !profileCap.check() {\n\t\t\taccount.unlink(Profile.publicPath)\n\t\t\tdestroy <- account.load<@AnyResource>(from:Profile.storagePath)\n\n\t\t\tlet profile <-Profile.createUser(name:name, createdAt: \"find\")\n\n\t\t\tlet fusdWallet=Profile.Wallet( name:\"FUSD\", receiver:fusdReceiver, balance:account.getCapability<&{FungibleToken.Balance}>(/public/fusdBalance), accept: Type<@FUSD.Vault>(), names: [\"fusd\", \"stablecoin\"])\n\n\t\t\tprofile.addWallet(fusdWallet)\n\t\t\tprofile.addCollection(Profile.ResourceCollection(\"FINDLeases\",leaseCollection, Type<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>(), [\"find\", \"leases\"]))\n\t\t\tprofile.addCollection(Profile.ResourceCollection(\"FINDBids\", bidCollection, Type<&FIND.BidCollection{FIND.BidCollectionPublic}>(), [\"find\", \"bids\"]))\n\n\t\t\taccount.save(<-profile, to: Profile.storagePath)\n\t\t\taccount.link<&Profile.User{Profile.Public}>(Profile.publicPath, target: Profile.storagePath)\n\t\t\taccount.link<&{FungibleToken.Receiver}>(Profile.publicReceiverPath, target: Profile.storagePath)\n\t\t}\n\n\t\tlet vaultRef = account.borrow<&FUSD.Vault>(from: /storage/fusdVault) ?? panic(\"Could not borrow reference to the fusdVault!\")\n\t\tlet vault <- vaultRef.withdraw(amount: amount) as! @FUSD.Vault\n\t\tlet bids = account.borrow<&FIND.BidCollection>(from: FIND.BidStoragePath)!\n\t\tbids.bid(name: name, vault: <- vault)\n\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "Profile": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "Profile",
+                        "fq_address": "A.0x37a05b1ecacc80f7.Profile",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138839731
+                    }
+                }
+            },
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138839716
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138839764
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            },
+            "amount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-bid.json
+++ b/templates/Blocto/find-bid.json
@@ -1,0 +1,69 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "882313c8a66a0d3e0deb4f93bec5db88933e51267ad9ae53b8f7956c88759ab8",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Bid"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Bid on a name {name} in FIND for {amount} FUSD"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\nimport FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\n\ntransaction(name: String, amount: UFix64) {\n\tprepare(account: AuthAccount) {\n\n\t\tlet vaultRef = account.borrow<&FUSD.Vault>(from: /storage/fusdVault) ?? panic(\"Could not borrow reference to the fusdVault!\")\n\t\t \n\t\tlet fusdReceiver = account.getCapability<&{FungibleToken.Receiver}>(/public/fusdReceiver)\n\n\t\tlet leaseCollection = account.getCapability<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>(FIND.LeasePublicPath)\n\t\tif !leaseCollection.check() {\n\t\t\taccount.unlink(FIND.LeasePublicPath)\n\t\t\tdestroy <- account.load<@AnyResource>(from:FIND.LeaseStoragePath)\n\t\t\taccount.save(<- FIND.createEmptyLeaseCollection(), to: FIND.LeaseStoragePath)\n\t\t\taccount.link<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>( FIND.LeasePublicPath, target: FIND.LeaseStoragePath)\n\t\t}\n\n\t\tlet bidCollection = account.getCapability<&FIND.BidCollection{FIND.BidCollectionPublic}>(FIND.BidPublicPath)\n\t\tif !bidCollection.check() {\n\t\t\taccount.unlink(FIND.BidPublicPath)\n\t\t\tdestroy <- account.load<@AnyResource>(from:FIND.BidStoragePath)\n\t\t\taccount.save(<- FIND.createEmptyBidCollection(receiver: fusdReceiver, leases: leaseCollection), to: FIND.BidStoragePath)\n\t\t\taccount.link<&FIND.BidCollection{FIND.BidCollectionPublic}>( FIND.BidPublicPath, target: FIND.BidStoragePath)\n\t\t}\n\n\t\tlet vault <- vaultRef.withdraw(amount: amount) as! @FUSD.Vault\n\t\tlet bids = account.borrow<&FIND.BidCollection>(from: FIND.BidStoragePath)!\n\t\tbids.bid(name: name, vault: <- vault)\n\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138839838
+                    }
+                }
+            },
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138839853
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138839881
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            },
+            "amount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-cancel-auction.json
+++ b/templates/Blocto/find-cancel-auction.json
@@ -1,0 +1,42 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "dd59645a0dbb2ddf006c7ed0483dc8f603502900674771289ab9921fda7b37bd",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Cancel auction"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Cancel and delist on ongoing auction for  {name}"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\n\ntransaction(name: String) {\n\tprepare(account: AuthAccount) {\n\n\t\tlet finLeases= account.borrow<&FIND.LeaseCollection>(from:FIND.LeaseStoragePath)!\n\t\tfinLeases.cancel(name)\n\t\tfinLeases.delistAuction(name)\n\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138839838
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-cancel-bid.json
+++ b/templates/Blocto/find-cancel-bid.json
@@ -1,0 +1,42 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "480de70c491fe02b21a333f3a99ed0007e0e57d525a920896250cb33871210d7",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Cancel bid"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Cancel your bid on {name}"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\n\ntransaction(name: String) {\n\tprepare(account: AuthAccount) {\n\t\tlet bids = account.borrow<&FIND.BidCollection>(from: FIND.BidStoragePath)!\n\t\tbids.cancelBid(name)\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138839853
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-create-profile.json
+++ b/templates/Blocto/find-create-profile.json
@@ -1,0 +1,75 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "78f6a08ed0c6652448e91396c1d3d88da29308e351211707466e8de50e5af3c1",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Create profile"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Create a profile with the name {name}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport FIND from 0xFIND_ADDRESS\nimport Profile from 0xFIND_ADDRESS\n\n\n//really not sure on how to input links here.)\ntransaction(name: String) {\n\tprepare(acct: AuthAccount) {\n\t\t//if we do not have a profile it might be stored under a different address so we will just remove it\n\t\tlet profileCap = acct.getCapability<&{Profile.Public}>(Profile.publicPath)\n\t\tif !profileCap.check() {\n\t\t\tacct.unlink(Profile.publicPath)\n\t\t\tdestroy <- acct.load<@AnyResource>(from:Profile.storagePath)\n\t\t}\n\n\t\t//TODO we already have a profile\n\t\tif profileCap.check() {\n\t\t\treturn \n\t\t}\n\n\t\tlet profile <-Profile.createUser(name:name, createdAt: \"find\")\n\n\t\t//Add exising FUSD or create a new one and add it\n\t\tlet fusdReceiver = acct.getCapability<&{FungibleToken.Receiver}>(/public/fusdReceiver)\n\t\tif !fusdReceiver.check() {\n\t\t\tlet fusd <- FUSD.createEmptyVault()\n\t\t\tacct.save(<- fusd, to: /storage/fusdVault)\n\t\t\tacct.link<&FUSD.Vault{FungibleToken.Receiver}>( /public/fusdReceiver, target: /storage/fusdVault)\n\t\t\tacct.link<&FUSD.Vault{FungibleToken.Balance}>( /public/fusdBalance, target: /storage/fusdVault)\n\t\t}\n\n\t\tlet fusdWallet=Profile.Wallet(\n\t\t\tname:\"FUSD\", \n\t\t\treceiver:acct.getCapability<&{FungibleToken.Receiver}>(/public/fusdReceiver),\n\t\t\tbalance:acct.getCapability<&{FungibleToken.Balance}>(/public/fusdBalance),\n\t\t\taccept: Type<@FUSD.Vault>(),\n\t\t\tnames: [\"fusd\", \"stablecoin\"]\n\t\t)\n\n\t\tprofile.addWallet(fusdWallet)\n\n\n\t\tlet flowWallet=Profile.Wallet(\n\t\t\tname:\"Flow\", \n\t\t\treceiver:acct.getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver),\n\t\t\tbalance:acct.getCapability<&{FungibleToken.Balance}>(/public/flowTokenBalance),\n\t\t\taccept: Type<@FlowToken.Vault>(),\n\t\t\tnames: [\"flow\"]\n\t\t)\n\t\tprofile.addWallet(flowWallet)\n\t\tlet leaseCollection = acct.getCapability<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>(FIND.LeasePublicPath)\n\t\tif !leaseCollection.check() {\n\t\t\tacct.unlink(FIND.LeasePublicPath)\n\t\t\tdestroy <- acct.load<@AnyResource>(from:FIND.LeaseStoragePath)\n\t\t\tacct.save(<- FIND.createEmptyLeaseCollection(), to: FIND.LeaseStoragePath)\n\t\t\tacct.link<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>( FIND.LeasePublicPath, target: FIND.LeaseStoragePath)\n\t\t}\n\t\tprofile.addCollection(Profile.ResourceCollection(\"FINDLeases\",leaseCollection, Type<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>(), [\"find\", \"leases\"]))\n\n\t\tlet bidCollection = acct.getCapability<&FIND.BidCollection{FIND.BidCollectionPublic}>(FIND.BidPublicPath)\n\t\tif !bidCollection.check() {\n\t\t\tacct.unlink(FIND.BidPublicPath)\n\t\t\tdestroy <- acct.load<@AnyResource>(from:FIND.BidStoragePath)\n\t\t\tacct.save(<- FIND.createEmptyBidCollection(receiver: fusdReceiver, leases: leaseCollection), to: FIND.BidStoragePath)\n\t\t\tacct.link<&FIND.BidCollection{FIND.BidCollectionPublic}>( FIND.BidPublicPath, target: FIND.BidStoragePath)\n\t\t}\n\t\tprofile.addCollection(Profile.ResourceCollection( \"FINDBids\", bidCollection, Type<&FIND.BidCollection{FIND.BidCollectionPublic}>(), [\"find\", \"bids\"]))\n\n\t\tacct.save(<-profile, to: Profile.storagePath)\n\t\tacct.link<&Profile.User{Profile.Public}>(Profile.publicPath, target: Profile.storagePath)\n\t\tacct.link<&{FungibleToken.Receiver}>(Profile.publicReceiverPath, target: Profile.storagePath)\n\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138839814
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138839948
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138839992
+                    }
+                }
+            },
+            "0xFIND_ADDRESS": {
+                "Profile": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "Profile",
+                        "fq_address": "A.0x37a05b1ecacc80f7.Profile",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138840117
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-delist-sale.json
+++ b/templates/Blocto/find-delist-sale.json
@@ -1,0 +1,42 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "b5107fddec7b17e95cbc6ad6d1b7ada399b9d607d780727305056a2c423e8c4b",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Delist sale"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Remove the listing of the name {name}"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\n\ntransaction(name: String) {\n\tprepare(acct: AuthAccount) {\n\t\tlet finLeases= acct.borrow<&FIND.LeaseCollection>(from:FIND.LeaseStoragePath)!\n\t\tfinLeases.delistSale(name)\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138839919
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-fulfill-auction-bidder.json
+++ b/templates/Blocto/find-fulfill-auction-bidder.json
@@ -1,0 +1,69 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "28442907b03c605a249d15be6e96324227a8d183880222246a6bc24e67f5a05a",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Fulfill auction bidder"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Fulfill the auction on {name}"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\nimport FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport Profile from 0xFIND_ADDRESS\n\ntransaction(owner: Address, name: String) {\n\tprepare(acct: AuthAccount) {\n\n\n\t//Add exising FUSD or create a new one and add it\n\t\tlet fusdReceiver = acct.getCapability<&{FungibleToken.Receiver}>(/public/fusdReceiver)\n\t\tif !fusdReceiver.check() {\n\t\t\tlet fusd <- FUSD.createEmptyVault()\n\t\t\tacct.save(<- fusd, to: /storage/fusdVault)\n\t\t\tacct.link<&FUSD.Vault{FungibleToken.Receiver}>( /public/fusdReceiver, target: /storage/fusdVault)\n\t\t\tacct.link<&FUSD.Vault{FungibleToken.Balance}>( /public/fusdBalance, target: /storage/fusdVault)\n\t\t}\n\n\t\tlet leaseCollection = acct.getCapability<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>(FIND.LeasePublicPath)\n\t\tif !leaseCollection.check() {\n\t\t\tacct.unlink(FIND.LeasePublicPath)\n\t\t\tdestroy <- acct.load<@AnyResource>(from:FIND.LeaseStoragePath)\n\n\t\t\tacct.save(<- FIND.createEmptyLeaseCollection(), to: FIND.LeaseStoragePath)\n\t\t\tacct.link<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>( FIND.LeasePublicPath, target: FIND.LeaseStoragePath)\n\t\t}\n\n\t\tlet bidCollection = acct.getCapability<&FIND.BidCollection{FIND.BidCollectionPublic}>(FIND.BidPublicPath)\n\t\tif !bidCollection.check() {\n\t\t\tacct.unlink(FIND.BidPublicPath)\n\t\t\tdestroy <- acct.load<@AnyResource>(from:FIND.BidStoragePath)\n\n\t\t\tacct.save(<- FIND.createEmptyBidCollection(receiver: fusdReceiver, leases: leaseCollection), to: FIND.BidStoragePath)\n\t\t\tacct.link<&FIND.BidCollection{FIND.BidCollectionPublic}>( FIND.BidPublicPath, target: FIND.BidStoragePath)\n\t\t}\n\n\t\tlet profileCap = acct.getCapability<&{Profile.Public}>(Profile.publicPath)\n\t\tif !profileCap.check() {\n\t\t\tacct.unlink(Profile.publicPath)\n\t\t\tdestroy <- acct.load<@AnyResource>(from:Profile.storagePath)\n\n\t\t\tlet profile <-Profile.createUser(name:name, createdAt: \"find\")\n\n\t\t\tlet fusdWallet=Profile.Wallet( name:\"FUSD\", receiver:fusdReceiver, balance:acct.getCapability<&{FungibleToken.Balance}>(/public/fusdBalance), accept: Type<@FUSD.Vault>(), names: [\"fusd\", \"stablecoin\"])\n\n\t\t\tprofile.addWallet(fusdWallet)\n\t\t\tprofile.addCollection(Profile.ResourceCollection(\"FINDLeases\",leaseCollection, Type<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>(), [\"find\", \"leases\"]))\n\t\t\tprofile.addCollection(Profile.ResourceCollection(\"FINDBids\", bidCollection, Type<&FIND.BidCollection{FIND.BidCollectionPublic}>(), [\"find\", \"bids\"]))\n\n\t\t\tacct.save(<-profile, to: Profile.storagePath)\n\t\t\tacct.link<&Profile.User{Profile.Public}>(Profile.publicPath, target: Profile.storagePath)\n\t\t\tacct.link<&{FungibleToken.Receiver}>(Profile.publicReceiverPath, target: Profile.storagePath)\n\t\t}\n\n\t\tlet leaseCollectionOwner = getAccount(owner).getCapability<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>(FIND.LeasePublicPath)\n\t\tleaseCollectionOwner.borrow()!.fulfillAuction(name)\n\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "Profile": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "Profile",
+                        "fq_address": "A.0x37a05b1ecacc80f7.Profile",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138840167
+                    }
+                }
+            },
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138840088
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138840117
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "owner": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "name": {
+                "index": 1,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-fulfill-auction.json
+++ b/templates/Blocto/find-fulfill-auction.json
@@ -1,0 +1,47 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "59d4395cff7deee69293e70cc4f00b05253f836852ba465b66d0ba42976dd18e",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Fulfill auction"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Fulfill the auction name {name}"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\n\ntransaction(owner: Address, name: String) {\n\tprepare(account: AuthAccount) {\n\n\t\tlet leaseCollection = getAccount(owner).getCapability<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>(FIND.LeasePublicPath)\n\t\tleaseCollection.borrow()!.fulfillAuction(name)\n\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138839987
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "owner": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "name": {
+                "index": 1,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-fulfill.json
+++ b/templates/Blocto/find-fulfill.json
@@ -1,0 +1,42 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ec8be3ae004b5fe2e5f561b4be8a842ab453dc297b9c16a40c3f769ef16f1189",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Fulfill"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Fulfill the auction on {name}"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\n\ntransaction(name: String) {\n\tprepare(account: AuthAccount) {\n\n\t\tlet finLeases= account.borrow<&FIND.LeaseCollection>(from:FIND.LeaseStoragePath)!\n\t\tfinLeases.fulfill(name)\n\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138839949
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-increase-bid.json
+++ b/templates/Blocto/find-increase-bid.json
@@ -1,0 +1,69 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "79049a059e6de8264e9b1318f1d18f8f057fa394146ed28e04cd544a00bacbf3",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Increase bid"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Increase your bid on name {name} in FIND with {amount} FUSD"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\nimport FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\n\ntransaction(name: String, amount: UFix64) {\n\tprepare(account: AuthAccount) {\n\n\t\tlet vaultRef = account.borrow<&FUSD.Vault>(from: /storage/fusdVault) ?? panic(\"Could not borrow reference to the fusdVault!\")\n\t\t\n\t\tlet fusdReceiver = account.getCapability<&{FungibleToken.Receiver}>(/public/fusdReceiver)\n\n\t\tlet leaseCollection = account.getCapability<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>(FIND.LeasePublicPath)\n\t\tif !leaseCollection.check() {\n\t\t\taccount.save(<- FIND.createEmptyLeaseCollection(), to: FIND.LeaseStoragePath)\n\t\t\taccount.link<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>( FIND.LeasePublicPath, target: FIND.LeaseStoragePath)\n\t\t}\n\n\t\tlet bidCollection = account.getCapability<&FIND.BidCollection{FIND.BidCollectionPublic}>(FIND.BidPublicPath)\n\t\tif !bidCollection.check() {\n\t\t\taccount.save(<- FIND.createEmptyBidCollection(receiver: fusdReceiver, leases: leaseCollection), to: FIND.BidStoragePath)\n\t\t\taccount.link<&FIND.BidCollection{FIND.BidCollectionPublic}>( FIND.BidPublicPath, target: FIND.BidStoragePath)\n\t\t}\n\n\n\t\tlet vault <- vaultRef.withdraw(amount: amount) as! @FUSD.Vault\n\t\tlet bids = account.borrow<&FIND.BidCollection>(from: FIND.BidStoragePath)!\n\t\tbids.increaseBid(name: name, vault: <- vault)\n\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138840060
+                    }
+                }
+            },
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138840082
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138840088
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            },
+            "amount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-list-for-auction.json
+++ b/templates/Blocto/find-list-for-auction.json
@@ -1,0 +1,62 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "7d621f05cfde59be8acd193ce70ee6fab857bed498b8056f94540fc95947c526",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find List for auction"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "List name {name} for auction with startPrice {auctionStartPrice} and reserve price {auctionReservePrice}"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\n\ntransaction(name: String, auctionStartPrice: UFix64, auctionReservePrice: UFix64, auctionDuration: UFix64, auctionExtensionOnLateBid: UFix64) {\n\tprepare(acct: AuthAccount) {\n\t\tlet finLeases= acct.borrow<&FIND.LeaseCollection>(from:FIND.LeaseStoragePath)!\n\t\tfinLeases.listForAuction(name: name, auctionStartPrice: auctionStartPrice, auctionReservePrice: auctionReservePrice, auctionDuration: auctionDuration,  auctionExtensionOnLateBid: auctionExtensionOnLateBid)\n\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138840088
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            },
+            "auctionStartPrice": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "auctionReservePrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "auctionDuration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "auctionExtensionOnLateBid": {
+                "index": 4,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-list-for-sale.json
+++ b/templates/Blocto/find-list-for-sale.json
@@ -1,0 +1,47 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "b09d98ee55696dd8ffb317bea1e7c58289df633c4a0c9f4f3a55144b60d4e874",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find List for sale"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "List name {name} for direct sale at {directSellPrice} FUSD"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\n\ntransaction(name: String, directSellPrice:UFix64) {\n\tprepare(acct: AuthAccount) {\n\t\tlet finLeases= acct.borrow<&FIND.LeaseCollection>(from:FIND.LeaseStoragePath)!\n\t\tfinLeases.listForSale(name: name,  directSellPrice:directSellPrice)\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138840172
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            },
+            "directSellPrice": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-register.json
+++ b/templates/Blocto/find-register.json
@@ -1,0 +1,80 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "d1b82a005b762654b684ecedb1f695b7809c188d4b5d5ab0c30ed01cfdf42779",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Register"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Register the name {name} in FIND for {amount} FUSD"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport Profile from 0xFIND_ADDRESS\nimport FIND from 0xFIND_ADDRESS\n\ntransaction(name: String, amount: UFix64) {\n\tprepare(acct: AuthAccount) {\n\n\t\t//Add exising FUSD or create a new one and add it\n\t\tlet fusdReceiver = acct.getCapability<&{FungibleToken.Receiver}>(/public/fusdReceiver)\n\t\tif !fusdReceiver.check() {\n\t\t\tlet fusd <- FUSD.createEmptyVault()\n\t\t\tacct.save(<- fusd, to: /storage/fusdVault)\n\t\t\tacct.link<&FUSD.Vault{FungibleToken.Receiver}>( /public/fusdReceiver, target: /storage/fusdVault)\n\t\t\tacct.link<&FUSD.Vault{FungibleToken.Balance}>( /public/fusdBalance, target: /storage/fusdVault)\n\t\t}\n\n\t\tlet leaseCollection = acct.getCapability<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>(FIND.LeasePublicPath)\n\t\tif !leaseCollection.check() {\n\t\t\tacct.unlink(FIND.LeasePublicPath)\n\t\t\tdestroy <- acct.load<@AnyResource>(from:FIND.LeaseStoragePath)\n\n\t\t\tacct.save(<- FIND.createEmptyLeaseCollection(), to: FIND.LeaseStoragePath)\n\t\t\tacct.link<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>( FIND.LeasePublicPath, target: FIND.LeaseStoragePath)\n\n\t\t}\n\n\t\tlet bidCollection = acct.getCapability<&FIND.BidCollection{FIND.BidCollectionPublic}>(FIND.BidPublicPath)\n\t\tif !bidCollection.check() {\n\t\t\tacct.unlink(FIND.BidPublicPath)\n\t\t\tdestroy <- acct.load<@AnyResource>(from:FIND.BidStoragePath)\n\n\t\t\tacct.save(<- FIND.createEmptyBidCollection(receiver: fusdReceiver, leases: leaseCollection), to: FIND.BidStoragePath)\n\t\t\tacct.link<&FIND.BidCollection{FIND.BidCollectionPublic}>( FIND.BidPublicPath, target: FIND.BidStoragePath)\n\t\t}\n\n\t\tlet profileCap = acct.getCapability<&{Profile.Public}>(Profile.publicPath)\n\t\tif !profileCap.check() {\n\t\t\tacct.unlink(Profile.publicPath)\n\t\t\tdestroy <- acct.load<@AnyResource>(from:Profile.storagePath)\n\n\t\t\tlet profile <-Profile.createUser(name:name, createdAt: \"find\")\n\n\t\t\tlet fusdWallet=Profile.Wallet( name:\"FUSD\", receiver:fusdReceiver, balance:acct.getCapability<&{FungibleToken.Balance}>(/public/fusdBalance), accept: Type<@FUSD.Vault>(), names: [\"fusd\", \"stablecoin\"])\n\n\t\t\tlet flowWallet=Profile.Wallet(\n\t\t\t\tname:\"Flow\", \n\t\t\t\treceiver:acct.getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver),\n\t\t\t\tbalance:acct.getCapability<&{FungibleToken.Balance}>(/public/flowTokenBalance),\n\t\t\t\taccept: Type<@FlowToken.Vault>(),\n\t\t\t\tnames: [\"flow\"]\n\t\t\t)\n\t\n\t\t\tprofile.addWallet(flowWallet)\n\t\t\tprofile.addWallet(fusdWallet)\n\t\t\tprofile.addCollection(Profile.ResourceCollection(\"FINDLeases\",leaseCollection, Type<&FIND.LeaseCollection{FIND.LeaseCollectionPublic}>(), [\"find\", \"leases\"]))\n\t\t\tprofile.addCollection(Profile.ResourceCollection(\"FINDBids\", bidCollection, Type<&FIND.BidCollection{FIND.BidCollectionPublic}>(), [\"find\", \"bids\"]))\n\n\t\t\tacct.save(<-profile, to: Profile.storagePath)\n\t\t\tacct.link<&Profile.User{Profile.Public}>(Profile.publicPath, target: Profile.storagePath)\n\t\t\tacct.link<&{FungibleToken.Receiver}>(Profile.publicReceiverPath, target: Profile.storagePath)\n\t\t}\n\n\t\tlet price=FIND.calculateCost(name)\n\t\tif price != amount {\n\t\t\tpanic(\"Calculated cost does not match expected cost\")\n\t\t}\n\t\tlog(\"The cost for registering this name is \".concat(price.toString()))\n\n\t\tlet vaultRef = acct.borrow<&FUSD.Vault>(from: /storage/fusdVault) ?? panic(\"Could not borrow reference to the fusdVault!\")\n\n\t\tlet payVault <- vaultRef.withdraw(amount: price) as! @FUSD.Vault\n\n\t\tlet leases=acct.borrow<&FIND.LeaseCollection>(from: FIND.LeaseStoragePath)!\n\t\tleases.register(name: name, vault: <- payVault)\n\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138840098
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138840147
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138840170
+                    }
+                }
+            },
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138840310
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            },
+            "amount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-reject-direct-offer.json
+++ b/templates/Blocto/find-reject-direct-offer.json
@@ -1,0 +1,42 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "735d355e9cfd01fb09e4f94051a3a2ddda1269ac2ae2b32c16adf13dadb6aa6e",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Reject direct offer"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Reject the offer received on {name}"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\n\ntransaction(name: String) {\n\tprepare(account: AuthAccount) {\n\n\t\tlet finLeases= account.borrow<&FIND.LeaseCollection>(from:FIND.LeaseStoragePath)!\n\t\tfinLeases.cancel(name)\n\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138840174
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-renew.json
+++ b/templates/Blocto/find-renew.json
@@ -1,0 +1,69 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "f752b682cd9fa3ba0d79b61b9f157c832f7942b14bfec8a2fee245a078350f9d",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Renew"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Renew the lease of name {name} in FIND for {amount} FUSD"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport Profile from 0xFIND_ADDRESS\nimport FIND from 0xFIND_ADDRESS\n\ntransaction(name: String, amount: UFix64) {\n\tprepare(acct: AuthAccount) {\n\n\t\tlet profileCap = acct.getCapability<&{Profile.Public}>(Profile.publicPath)\n\n\t\tlet price=FIND.calculateCost(name)\n\t\tif amount != price {\n\t\t\tpanic(\"expected renew cost is not the same as calculated renew cost\")\n\t\t}\n\t\tlet vaultRef = acct.borrow<&FUSD.Vault>(from: /storage/fusdVault) ?? panic(\"Could not borrow reference to the fusdVault!\")\n\t\tlet payVault <- vaultRef.withdraw(amount: price) as! @FUSD.Vault\n\n\t\tlet finLeases= acct.borrow<&FIND.LeaseCollection>(from:FIND.LeaseStoragePath)!\n\t\tlet finToken= finLeases.borrow(name)\n\t\tfinToken.extendLease(<- payVault)\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138840172
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138840203
+                    }
+                }
+            },
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138840383
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            },
+            "amount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/find-start-auction.json
+++ b/templates/Blocto/find-start-auction.json
@@ -1,0 +1,42 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "e50336ba216a4a9d9f24004e7a312e6669f91301d2fc6a570947a8a53da66692",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Find Start auction"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Manually start an auction on {name}"
+                }
+            }
+        },
+        "cadence": "import FIND from 0xFIND_ADDRESS\n\ntransaction(name: String) {\n\tprepare(account: AuthAccount) {\n\n\t\tlet finLeases= account.borrow<&FIND.LeaseCollection>(from:FIND.LeaseStoragePath)!\n\t\tfinLeases.startAuction(name)\n\n\t}\n}\n\n",
+        "dependencies": {
+            "0xFIND_ADDRESS": {
+                "FIND": {
+                    "testnet": {
+                        "address": "0x37a05b1ecacc80f7",
+                        "contract": "FIND",
+                        "fq_address": "A.0x37a05b1ecacc80f7.FIND",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138840410
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "name": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/flowstaking-claim-reward-flow.json
+++ b/templates/Blocto/flowstaking-claim-reward-flow.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "0d0201f4bd75d9e29211f8b9555e003bc753e4487e95695dbf2e9a0fd1c867b6",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FlowStaking Claim reward flow"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Claim staking reward: {amount} FLOW",
+                    "zh-CN": "领取质押奖励: {amount} FLOW 代币",
+                    "zh-TW": "領取質押獎勵: {amount} FLOW 代幣"
+                }
+            }
+        },
+        "cadence": "import LockedTokens from 0xLOCKED_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\ntransaction(amount: UFix64) {\n  let nodeDelegatorProxy: LockedTokens.LockedNodeDelegatorProxy\n  let holderRef: &LockedTokens.TokenHolder\n  let vaultRef: &FlowToken.Vault\n\n  prepare(acct: AuthAccount) {\n    self.holderRef = acct.borrow<&LockedTokens.TokenHolder>(from: LockedTokens.TokenHolderStoragePath) \n      ?? panic(\"TokenHolder is not saved at specified path\")\n    \n    self.nodeDelegatorProxy = self.holderRef.borrowDelegator()\n\n    self.vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n      ?? panic(\"Could not borrow flow token vault ref\")\n  }\n\n  execute {\n    self.nodeDelegatorProxy.withdrawRewardedTokens(amount: amount)\n    self.vaultRef.deposit(from: <-self.holderRef.withdraw(amount: amount))\n  }\n}",
+        "dependencies": {
+            "0xLOCKED_TOKEN_ADDRESS": {
+                "LockedTokens": {
+                    "testnet": {
+                        "address": "0x95e019a17d0e23d7",
+                        "contract": "LockedTokens",
+                        "fq_address": "A.0x95e019a17d0e23d7.LockedTokens",
+                        "pin": "8c6baff06e290c032e1dabac5b99c800ef040b06bec84d351d03927c4daf7e75",
+                        "pin_block_height": 138839547
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138839565
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/flowstaking-claim-unstaked-flow.json
+++ b/templates/Blocto/flowstaking-claim-unstaked-flow.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "2548bc984f0af09807ddd7d9a7234e67f98ecfd99549726714a9b0ea1ce24516",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FlowStaking Claim unstaked flow"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Claim unstaked tokens: {amount} FLOW",
+                    "zh-CN": "領取解除质押的代币: {amount} FLOW 代币",
+                    "zh-TW": "領取解除質押的代幣: {amount} FLOW 代幣"
+                }
+            }
+        },
+        "cadence": "import LockedTokens from 0xLOCKED_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\ntransaction(amount: UFix64) {\n  let nodeDelegatorProxy: LockedTokens.LockedNodeDelegatorProxy\n  let holderRef: &LockedTokens.TokenHolder\n  let vaultRef: &FlowToken.Vault\n\n  prepare(acct: AuthAccount) {\n    self.holderRef = acct.borrow<&LockedTokens.TokenHolder>(from: LockedTokens.TokenHolderStoragePath) \n      ?? panic(\"TokenHolder is not saved at specified path\")\n\n    self.vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n      ?? panic(\"Could not borrow flow token vault ref\")\n    \n    self.nodeDelegatorProxy = self.holderRef.borrowDelegator()\n  }\n\n  execute {\n    self.nodeDelegatorProxy.withdrawUnstakedTokens(amount: amount)\n\n    // Unlock as much as possible\n    let limit = self.holderRef.getUnlockLimit()\n    let max = limit > amount ? amount : limit\n    \n    if (max > 0.0) {\n      self.vaultRef.deposit(from: <-self.holderRef.withdraw(amount: max))\n    }\n  } \n}",
+        "dependencies": {
+            "0xLOCKED_TOKEN_ADDRESS": {
+                "LockedTokens": {
+                    "testnet": {
+                        "address": "0x95e019a17d0e23d7",
+                        "contract": "LockedTokens",
+                        "fq_address": "A.0x95e019a17d0e23d7.LockedTokens",
+                        "pin": "8c6baff06e290c032e1dabac5b99c800ef040b06bec84d351d03927c4daf7e75",
+                        "pin_block_height": 138839565
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138839583
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/flowstaking-enable-flow-stake.json
+++ b/templates/Blocto/flowstaking-enable-flow-stake.json
@@ -1,0 +1,109 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "1b5b84ce7a8bce673342e7f32306ace5967a7406b950cc4d91733c7a2de12332",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FlowStaking Enable flow stake"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Enable staking: {amount} FLOW",
+                    "zh-CN": "启用质押: {amount} FLOW 代币",
+                    "zh-TW": "啟用質押: {amount} FLOW 代幣"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport LockedTokens from 0xLOCKED_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport FlowStorageFees from 0xFLOW_STORAGE_FEES_ADDRESS\nimport BloctoStorageRent from 0xBLOCTO_STORAGE_RENT_ADDRESS\nimport FlowIDTableStaking from 0xFLOW_ID_TABLE_STAKING_ADDRESS\n\ntransaction(id: String, amount: UFix64, cosignerPubKey: String) {\n\n  let holderRef: &LockedTokens.TokenHolder\n  \n  let vaultRef: &FlowToken.Vault\n\n  prepare(custodyProvider: AuthAccount, userAccount: AuthAccount) {\n\n    let sharedAccount = AuthAccount(payer: custodyProvider)\n\n    // Add a key\n    sharedAccount.keys.add(\n      publicKey: PublicKey(\n          publicKey: cosignerPubKey.decodeHex(),\n          signatureAlgorithm: SignatureAlgorithm.ECDSA_secp256k1\n      ),\n      hashAlgorithm: HashAlgorithm.SHA3_256,\n      weight: 1000.0\n    )\n\n    let vaultCapability = sharedAccount.link<&FlowToken.Vault>(\n      /private/flowTokenVault, \n      target: /storage/flowTokenVault\n    ) ?? panic(\"Could not link Flow Token Vault capability\")\n\n    let lockedTokenManager <- LockedTokens.createLockedTokenManager(vault: vaultCapability)\n\n    sharedAccount.save(<-lockedTokenManager, to: LockedTokens.LockedTokenManagerStoragePath)\n\n    let tokenManagerCapability = sharedAccount.link<&LockedTokens.LockedTokenManager>(\n      LockedTokens.LockedTokenManagerPrivatePath, \n      target: LockedTokens.LockedTokenManagerStoragePath\n    ) ?? panic(\"Could not link token manager capability\")\n\n    let tokenHolder <- LockedTokens.createTokenHolder(\n      lockedAddress: sharedAccount.address, \n      tokenManager: tokenManagerCapability\n    )\n\n    userAccount.save(<-tokenHolder, to: LockedTokens.TokenHolderStoragePath)\n\n    userAccount.link<&LockedTokens.TokenHolder{LockedTokens.LockedAccountInfo}>(\n      LockedTokens.LockedAccountInfoPublicPath, \n      target: LockedTokens.TokenHolderStoragePath\n    )\n\n    let tokenAdminCapability = sharedAccount.link<&LockedTokens.LockedTokenManager>(\n      LockedTokens.LockedTokenAdminPrivatePath, \n      target: LockedTokens.LockedTokenManagerStoragePath\n    ) ?? panic(\"Could not link token custodyProvider to token manager\")\n\n    let lockedAccountCreator = custodyProvider.borrow<&LockedTokens.LockedAccountCreator>(\n      from: LockedTokens.LockedAccountCreatorStoragePath\n    ) ?? panic(\"Could not borrow reference to LockedAccountCreator\")\n\n    lockedAccountCreator.addAccount(\n      sharedAccountAddress: sharedAccount.address, \n      unlockedAccountAddress: userAccount.address, \n      tokenAdmin: tokenAdminCapability\n    )\n\n    // Override the default FlowToken receiver\n    sharedAccount.unlink(/public/flowTokenReceiver)\n\n    // create new receiver that marks received tokens as unlocked\n    sharedAccount.link<&AnyResource{FungibleToken.Receiver}>(\n      /public/flowTokenReceiver, \n      target: LockedTokens.LockedTokenManagerStoragePath\n    )\n\n    // pub normal receiver in a separate unique path\n    sharedAccount.link<&AnyResource{FungibleToken.Receiver}>(\n      /public/lockedFlowTokenReceiver, \n      target: /storage/flowTokenVault\n    )\n\n    BloctoStorageRent.tryRefill(custodyProvider.address)\n    BloctoStorageRent.tryRefill(userAccount.address)\n\n    self.holderRef = userAccount.borrow<&LockedTokens.TokenHolder>(\n      from: LockedTokens.TokenHolderStoragePath\n    ) ?? panic(\"TokenHolder is not saved at specified path\")\n    \n    self.vaultRef = userAccount.borrow<&FlowToken.Vault>(\n      from: /storage/flowTokenVault\n    ) ?? panic(\"Could not borrow flow token vault reference\")\n  }\n\n  execute {\n    let lockedBalance = self.holderRef.getLockedAccountBalance()\n\n    if amount <= lockedBalance {\n      self.holderRef.createNodeDelegator(nodeID: id)\n      let stakerProxy = self.holderRef.borrowDelegator()\n      stakerProxy.delegateNewTokens(amount: amount - FlowIDTableStaking.getDelegatorMinimumStakeRequirement())\n    } else if ((amount - lockedBalance) <= (self.vaultRef.balance - FlowStorageFees.minimumStorageReservation)) {\n      self.holderRef.deposit(from: <-self.vaultRef.withdraw(amount: amount - lockedBalance))\n      self.holderRef.createNodeDelegator(nodeID: id)\n      let stakerProxy = self.holderRef.borrowDelegator()\n      stakerProxy.delegateNewTokens(amount: amount - FlowIDTableStaking.getDelegatorMinimumStakeRequirement())\n    } else {\n      panic(\"Not enough tokens to stake!\")\n    }\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138839387
+                    }
+                }
+            },
+            "0xLOCKED_TOKEN_ADDRESS": {
+                "LockedTokens": {
+                    "testnet": {
+                        "address": "0x95e019a17d0e23d7",
+                        "contract": "LockedTokens",
+                        "fq_address": "A.0x95e019a17d0e23d7.LockedTokens",
+                        "pin": "8c6baff06e290c032e1dabac5b99c800ef040b06bec84d351d03927c4daf7e75",
+                        "pin_block_height": 138839583
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138839623
+                    }
+                }
+            },
+            "0xFLOW_STORAGE_FEES_ADDRESS": {
+                "FlowStorageFees": {
+                    "testnet": {
+                        "address": "0x8c5303eaa26202d6",
+                        "contract": "FlowStorageFees",
+                        "fq_address": "A.0x8c5303eaa26202d6.FlowStorageFees",
+                        "pin": "ec7be5050256b8b9ab2a6f5550a42b6a64627fa7e684a88de5dd767864f0471a",
+                        "pin_block_height": 138839693
+                    }
+                }
+            },
+            "0xBLOCTO_STORAGE_RENT_ADDRESS": {
+                "BloctoStorageRent": {
+                    "testnet": {
+                        "address": "0xe563b9f8c70ab608",
+                        "contract": "BloctoStorageRent",
+                        "fq_address": "A.0xe563b9f8c70ab608.BloctoStorageRent",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138839731
+                    }
+                }
+            },
+            "0xFLOW_ID_TABLE_STAKING_ADDRESS": {
+                "FlowIDTableStaking": {
+                    "testnet": {
+                        "address": "0x9eca2b38b18b5dfe",
+                        "contract": "FlowIDTableStaking",
+                        "fq_address": "A.0x9eca2b38b18b5dfe.FlowIDTableStaking",
+                        "pin": "36de04e524c1ae3d1ff6f87448f31576e302f6402d9505aed5ef3c9ca295b0de",
+                        "pin_block_height": 138839853
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            },
+            "amount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "cosignerPubKey": {
+                "index": 2,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/flowstaking-request-to-unstake-flow.json
+++ b/templates/Blocto/flowstaking-request-to-unstake-flow.json
@@ -1,0 +1,44 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "74e113985719b7ad1d797686c8968bf179866dd15106bf6de4fe0719e1be9185",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FlowStaking Request to unstake flow"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Request to unstake: {amount} FLOW",
+                    "zh-CN": "请求解除质押: {amount} FLOW 代币",
+                    "zh-TW": "請求解除質押: {amount} FLOW 代幣"
+                }
+            }
+        },
+        "cadence": "import LockedTokens from 0xLOCKED_TOKEN_ADDRESS\n\ntransaction(amount: UFix64) {\n  let nodeDelegatorProxy: LockedTokens.LockedNodeDelegatorProxy\n\n  prepare(acct: AuthAccount) {\n    let holderRef = acct.borrow<&LockedTokens.TokenHolder>(from: LockedTokens.TokenHolderStoragePath) \n      ?? panic(\"TokenHolder is not saved at specified path\")\n    \n    self.nodeDelegatorProxy = holderRef.borrowDelegator()\n  }\n\n  execute {\n    self.nodeDelegatorProxy.requestUnstaking(amount: amount)\n  }\n}",
+        "dependencies": {
+            "0xLOCKED_TOKEN_ADDRESS": {
+                "LockedTokens": {
+                    "testnet": {
+                        "address": "0x95e019a17d0e23d7",
+                        "contract": "LockedTokens",
+                        "fq_address": "A.0x95e019a17d0e23d7.LockedTokens",
+                        "pin": "8c6baff06e290c032e1dabac5b99c800ef040b06bec84d351d03927c4daf7e75",
+                        "pin_block_height": 138839573
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/flowstaking-stake-new-flow.json
+++ b/templates/Blocto/flowstaking-stake-new-flow.json
@@ -1,0 +1,77 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "9902c5c3c8d089f775b410d8eab62571787bcf421d0c3ddc4b077374ecf45bb3",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FlowStaking Stake new flow"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Request to stake: {amount} FLOW",
+                    "zh-CN": "请求质押: {amount} FLOW 代币",
+                    "zh-TW": "請求質押: {amount} FLOW 代幣"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport LockedTokens from 0xLOCKED_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport FlowStorageFees from 0xFLOW_STORAGE_FEES_ADDRESS\n\ntransaction(amount: UFix64) {\n\n  let holderRef: &LockedTokens.TokenHolder\n\n  let vaultRef: &FlowToken.Vault\n\n  prepare(account: AuthAccount) {\n    self.holderRef = account.borrow<&LockedTokens.TokenHolder>(from: LockedTokens.TokenHolderStoragePath)\n      ?? panic(\"Could not borrow reference to TokenHolder\")\n\n    self.vaultRef = account.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n      ?? panic(\"Could not borrow flow token vault reference\")\n  }\n\n  execute {\n    let delegatorProxy = self.holderRef.borrowDelegator()\n    let lockedBalance = self.holderRef.getLockedAccountBalance()\n\n    if amount <= lockedBalance {\n      delegatorProxy.delegateNewTokens(amount: amount)\n    } else if ((amount - lockedBalance) <= self.vaultRef.balance - FlowStorageFees.minimumStorageReservation) {\n      self.holderRef.deposit(from: <-self.vaultRef.withdraw(amount: amount - lockedBalance))\n      delegatorProxy.delegateNewTokens(amount: amount)\n    } else {\n      panic(\"Not enough tokens to stake!\")\n    }\n  }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138839476
+                    }
+                }
+            },
+            "0xLOCKED_TOKEN_ADDRESS": {
+                "LockedTokens": {
+                    "testnet": {
+                        "address": "0x95e019a17d0e23d7",
+                        "contract": "LockedTokens",
+                        "fq_address": "A.0x95e019a17d0e23d7.LockedTokens",
+                        "pin": "8c6baff06e290c032e1dabac5b99c800ef040b06bec84d351d03927c4daf7e75",
+                        "pin_block_height": 138839669
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138839698
+                    }
+                }
+            },
+            "0xFLOW_STORAGE_FEES_ADDRESS": {
+                "FlowStorageFees": {
+                    "testnet": {
+                        "address": "0x8c5303eaa26202d6",
+                        "contract": "FlowStorageFees",
+                        "fq_address": "A.0x8c5303eaa26202d6.FlowStorageFees",
+                        "pin": "ec7be5050256b8b9ab2a6f5550a42b6a64627fa7e684a88de5dd767864f0471a",
+                        "pin_block_height": 138839731
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/flowstaking-stake-unstaked-flow.json
+++ b/templates/Blocto/flowstaking-stake-unstaked-flow.json
@@ -1,0 +1,44 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "b07dbf0e292d6231f2a0b4eb559384a678e63856153764d3c7cd9b57ac3e5ab9",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FlowStaking Stake unstaked flow"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Request to re-stake unstaked tokens: {amount} FLOW",
+                    "zh-CN": "请求重新质押解除质押的代币: {amount} FLOW 代币",
+                    "zh-TW": "請求重新質押解除質押的代幣: {amount} FLOW 代幣"
+                }
+            }
+        },
+        "cadence": "import LockedTokens from 0xLOCKED_TOKEN_ADDRESS\n\ntransaction(amount: UFix64) {\n  let nodeDelegatorProxy: LockedTokens.LockedNodeDelegatorProxy\n\n  prepare(acct: AuthAccount) {\n    let holderRef = acct.borrow<&LockedTokens.TokenHolder>(from: LockedTokens.TokenHolderStoragePath) \n      ?? panic(\"TokenHolder is not saved at specified path\")\n\n    self.nodeDelegatorProxy = holderRef.borrowDelegator()\n  }\n\n  execute {\n    self.nodeDelegatorProxy.delegateUnstakedTokens(amount: amount)\n  }\n}",
+        "dependencies": {
+            "0xLOCKED_TOKEN_ADDRESS": {
+                "LockedTokens": {
+                    "testnet": {
+                        "address": "0x95e019a17d0e23d7",
+                        "contract": "LockedTokens",
+                        "fq_address": "A.0x95e019a17d0e23d7.LockedTokens",
+                        "pin": "8c6baff06e290c032e1dabac5b99c800ef040b06bec84d351d03927c4daf7e75",
+                        "pin_block_height": 138839743
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/flowtoken-send-flow-token.json
+++ b/templates/Blocto/flowtoken-send-flow-token.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "009d0746500bced68f7a7d052b610264103c961e43697299cba74f747846bb4f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "FlowToken Send flow token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Send {amount} FLOW to {to}",
+                    "zh-CN": "发送 {amount} FLOW 代币至 {to}",
+                    "zh-TW": "發送 {amount} FLOW 代幣至 {to}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\ntransaction(amount: UFix64, to: Address) {\n\n    // The Vault resource that holds the tokens that are being transferred\n    let sentVault: @FungibleToken.Vault\n\n    prepare(signer: AuthAccount) {\n\n        // Get a reference to the signer's stored vault\n        let vaultRef = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow reference to the owner's Vault!\")\n\n        // Withdraw tokens from the signer's stored vault\n        self.sentVault <- vaultRef.withdraw(amount: amount)\n    }\n\n    execute {\n\n        // Get the recipient's public account object\n        let recipient = getAccount(to)\n\n        // Get a reference to the recipient's Receiver\n        let receiverRef = recipient.getCapability(/public/flowTokenReceiver)\n            .borrow<&{FungibleToken.Receiver}>()\n            ?? panic(\"Could not borrow receiver reference to the recipient's Vault\")\n\n        // Deposit the withdrawn tokens in the recipient's receiver\n        receiverRef.deposit(from: <-self.sentVault)\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 139076708
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 139076763
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "to": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/gaia-borrow-money-by-nft.json
+++ b/templates/Blocto/gaia-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ca4dfc53f4cae22e0a207d7bc63676fa6a4ddc7dbfad5dc5fad4b0dd1a182104",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Gaia Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/GaiaCollection001)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889174
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889216
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889265
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889318
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/gaia-cancel-borrow-money.json
+++ b/templates/Blocto/gaia-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "6f2efbc316187ee15b41cf8af25f4750869e3abd68d768636e4395bc43e0af88",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Gaia Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/GaiaCollection001)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889178
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889259
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/gaia-force-redeem.json
+++ b/templates/Blocto/gaia-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "c6395e826ed68ac9f7039f1c5f5c9a7bfc536d303130a202ce1638df02fa8330",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Gaia Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/GaiaCollection001)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889258
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889319
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/gaia-lend-money.json
+++ b/templates/Blocto/gaia-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "42019b8412e4aae83585f52f071050673d64466854b6e86f1d39b960152930f7",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Gaia Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889302
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889329
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/gaia-repay.json
+++ b/templates/Blocto/gaia-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ad63160882d4b0c1cc66fad4cf050b8a219a445d454cc7732c65cdeae18ebfb6",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Gaia Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/GaiaCollection001)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889288
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889354
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889375
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/geniacenft-borrow-money-by-nft.json
+++ b/templates/Blocto/geniacenft-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "2b34e1059eea5379c9977b03ae9b2f7df5b3ce4de4d9ad01efd2df7dd75bcdf1",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "GeniaceNFT Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/GeniaceNFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890537
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890580
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890643
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890668
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/geniacenft-cancel-borrow-money.json
+++ b/templates/Blocto/geniacenft-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "a4d9dae4cdbae97f4ad52921b3347ca98af53b87b7f97a138113d4adadb9cf01",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "GeniaceNFT Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/GeniaceNFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890579
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890654
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/geniacenft-force-redeem.json
+++ b/templates/Blocto/geniacenft-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "c19b5ff0b0001431f75358d4c736944037f9d5af3b54c8d07ce26b4076fd8da7",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "GeniaceNFT Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/GeniaceNFTCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890579
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890643
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/geniacenft-lend-money.json
+++ b/templates/Blocto/geniacenft-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "0905b9b4ef332699ddd6c9ac6b1852e8964c89ffe51b3893b12be7241692af0a",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "GeniaceNFT Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890643
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890670
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/geniacenft-repay.json
+++ b/templates/Blocto/geniacenft-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "5b07e138b8d8f2fa7ed6b782c6c04b524a646d84501e312a54b6f73d9f36d1e5",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "GeniaceNFT Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/GeniaceNFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890652
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890711
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890764
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/gogoro-claim-gogoro-nft.json
+++ b/templates/Blocto/gogoro-claim-gogoro-nft.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "b44e8b8d1dea65cd34604302f045e4f01bfe758ce8cafe95d5c49b584de3ffc0",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Gogoro Claim gogoro nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Claim Gogoro NFT",
+                    "zh-CN": "领取 Gogogo NFT",
+                    "zh-TW": "領取 Gogogo NFT"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport GogoroCollectible from 0xGOGORO_COLLECTIBLE_ADDRESS\nimport BloctoStorageRent from 0xBLOCTO_STORAGE_RENT_ADDRESS\n\ntransaction(itemID: UInt64, codeHash: String) {\n    let minter: &GogoroCollectible.Admin\n    let userAddress: Address\n    prepare(user: AuthAccount, admin: AuthAccount) {\n        self.minter = admin\n            .borrow<&GogoroCollectible.Admin>(from: GogoroCollectible.AdminStoragePath)\n            ?? panic(\"admin account is not the minter\")\n        self.userAddress = user.address\n        // If user does not have Gogoro enabled yet, enable now\n        if user.borrow<&GogoroCollectible.Collection>(from: GogoroCollectible.CollectionStoragePath) == nil {\n            let collection <- GogoroCollectible.createEmptyCollection() as! @GogoroCollectible.Collection\n            user.save(<-collection, to: GogoroCollectible.CollectionStoragePath)\n            user.link<&GogoroCollectible.Collection{NonFungibleToken.CollectionPublic, GogoroCollectible.CollectionPublic}>(\n                GogoroCollectible.CollectionPublicPath,\n                target: GogoroCollectible.CollectionStoragePath)\n        }\n    }\n    execute {\n        let userAccount = getAccount(self.userAddress)\n        let receiverRef = userAccount.getCapability(GogoroCollectible.CollectionPublicPath)\n            .borrow<&{NonFungibleToken.CollectionPublic}>()\n            ?? panic(\"Could not borrow receiver reference to the user's collection\")\n        self.minter.mintNFT(recipient: receiverRef, itemID: itemID, codeHash: codeHash)\n        // Replenish storage fee\n        BloctoStorageRent.tryRefill(self.userAddress)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138839615
+                    }
+                }
+            },
+            "0xGOGORO_COLLECTIBLE_ADDRESS": {
+                "GogoroCollectible": {
+                    "testnet": {
+                        "address": "0x5fc35f03a6f33561",
+                        "contract": "GogoroCollectible",
+                        "fq_address": "A.0x5fc35f03a6f33561.GogoroCollectible",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138839692
+                    }
+                }
+            },
+            "0xBLOCTO_STORAGE_RENT_ADDRESS": {
+                "BloctoStorageRent": {
+                    "testnet": {
+                        "address": "0xe563b9f8c70ab608",
+                        "contract": "BloctoStorageRent",
+                        "fq_address": "A.0xe563b9f8c70ab608.BloctoStorageRent",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138839731
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "itemID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "codeHash": {
+                "index": 1,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/gooberz-borrow-money-by-nft.json
+++ b/templates/Blocto/gooberz-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "5238474696dabb187cd569a5aef7f860601da3c50599d5e31ce9afd60f3a0200",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Gooberz Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/GooberzPartyFolksCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889288
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889318
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889375
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889424
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/gooberz-cancel-borrow-money.json
+++ b/templates/Blocto/gooberz-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ac5ca9c6ba17c1b77c8e2032171167fb3f59ebc04bee14f755188d77bbc1fbd9",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Gooberz Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/GooberzPartyFolksCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889344
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889415
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/gooberz-force-redeem.json
+++ b/templates/Blocto/gooberz-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "8e51cac0d3d61fbbc51db957aae3229c9584d76d705af3694994649c7666e5ff",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Gooberz Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/GooberzPartyFolksCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889354
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889441
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/gooberz-lend-money.json
+++ b/templates/Blocto/gooberz-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "f50001f18454fe1676f3431ef53d7b34891ba8db081eb47b3000c2759e3e4305",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Gooberz Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889424
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889462
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/gooberz-repay.json
+++ b/templates/Blocto/gooberz-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "910dd38a59633c83c596fb4bd6b152e935598dce98f1dd1510b9e94a4c9ab48c",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Gooberz Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/GooberzPartyFolksCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889415
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889479
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889519
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/matrixworldflowfestnft-borrow-money-by-nft.json
+++ b/templates/Blocto/matrixworldflowfestnft-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "7c4cbcf32a3eec8e0ae88d51fb261a9de35c74c44f8087b81982fc9f31ed63d0",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "MatrixWorldFlowFestNFT Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MatrixWorldFlowFestNFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889432
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889462
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889536
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889553
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/matrixworldflowfestnft-cancel-borrow-money.json
+++ b/templates/Blocto/matrixworldflowfestnft-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "1d7394645eb61d158bfff83b1e5bc178d8da64bb755b8b9397a96552585b6f01",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "MatrixWorldFlowFestNFT Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MatrixWorldFlowFestNFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889441
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889519
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/matrixworldflowfestnft-force-redeem.json
+++ b/templates/Blocto/matrixworldflowfestnft-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "95e961869afef7b6d7d455f55a084d70dabf7dc8c09ed95808143974ed6233aa",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "MatrixWorldFlowFestNFT Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MatrixWorldFlowFestNFTCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889479
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889553
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/matrixworldflowfestnft-lend-money.json
+++ b/templates/Blocto/matrixworldflowfestnft-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "d3d03a671494e54def86bc61ee807fc453520bd52b80d2ddbb498a0e8bd7ef25",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "MatrixWorldFlowFestNFT Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889600
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889625
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/matrixworldflowfestnft-repay.json
+++ b/templates/Blocto/matrixworldflowfestnft-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "cacd5dfa661aff4bc686b9c1d8f60ac0a8e8826dca30f5ac1048990e14253957",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "MatrixWorldFlowFestNFT Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MatrixWorldFlowFestNFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889502
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889555
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889600
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/mikoseamarket-create-listing.json
+++ b/templates/Blocto/mikoseamarket-create-listing.json
@@ -1,0 +1,102 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "f9486a4b24d8606590855ffb7c433b023101d329e9a8c1fb8d48a4c37667586e",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "MikoSeaMarket Create listing"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Create listing"
+                }
+            }
+        },
+        "cadence": "// createListingV1.1\nimport MikoSeaMarket from 0xMIKOSEA_MARKET_ADDRESS\nimport MIKOSEANFT from 0xMIKOSEA_MIKOSEANFT_ADDRESS\nimport MIKOSEANFTV2 from 0xMIKOSEA_MIKOSEANFTV2_ADDRESS\nimport FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport MetadataViews from 0xMETADATA_VIEWS_ADDRESS\n\npub fun getNftV2Metadata(addr: Address, nftID: UInt64): {String:String} {\n    let account = getAccount(addr)\n    let collectioncap = account.getCapability<&{MIKOSEANFTV2.CollectionPublic}>(MIKOSEANFTV2.CollectionPublicPath)\n    let collectionRef = collectioncap.borrow() ?? panic(\"Could not borrow collection capability\")\n\n    let nft = collectionRef.borrowMIKOSEANFTV2(id: nftID)\n    if nft == nil {\n        return {}\n    }\n    let nftAs = nft!\n    return nftAs.getMetadata()\n}\n\npub fun validateNftExpeiredDate(nftType: String, address: Address, nftID: UInt64) {\n    if nftType == \"mikoseav2\" {\n        let metadata = getNftV2Metadata(addr: address, nftID: nftID)\n        let start_at_unix = UInt64.fromString(metadata[\"start_at\"] ?? \"\")\n        let end_at_unix = UInt64.fromString(metadata[\"end_at\"] ?? \"\")\n        let next_expired_at_unix = UInt64.fromString(metadata[\"next_expired_at\"] ?? \"\")\n        let currentTime = getCurrentBlock().timestamp\n\n        if start_at_unix != nil {\n            if UFix64(start_at_unix!) > currentTime {\n                panic(\"NFT_START_AT_IS_INVALID\")\n            }\n        }\n        if end_at_unix != nil {\n            if UFix64(end_at_unix!) < currentTime {\n                panic(\"NFT_END_AT_IS_INVALID\")\n            }\n        }\n        if next_expired_at_unix != nil {\n            if UFix64(next_expired_at_unix!) < currentTime {\n                panic(\"NFT_NEXT_EXPIRED_AT_IS_INVALID\")\n            }\n        }\n    }\n}\n\npub fun getRoyaltiesV1(address: Address, nftID: UInt64): MetadataViews.Royalties {\n    if !MIKOSEANFT.checkCollection(address) {\n        panic(\"ACCOUNT_NOT_SETUP\")\n    }\n\n    // check holder holds NFT\n    let nftData = MIKOSEANFT.fetch(_from: address, itemId:nftID) ?? panic(\"NFT_NOT_FOUND\")\n    let projectId = nftData.data.projectId\n\n    let projectCreatorFee = MIKOSEANFT.getProjectCreatorFee(projectId: projectId) ?? 0.1\n    let projectCreatorAddress = MIKOSEANFT.getProjectCreatorAddress(projectId: projectId)!\n    let platfromFee = MIKOSEANFT.getProjectPlatformFee(projectId: projectId) ?? 0.05\n    return MetadataViews.Royalties([\n        MetadataViews.Royalty(\n            receiver: getAccount(projectCreatorAddress).getCapability<&AnyResource{FungibleToken.Receiver}>(MIKOSEANFT.CollectionPublicPath),\n            cut: projectCreatorFee,\n            description: \"Creator fee\"\n        ),\n        MetadataViews.Royalty(\n            receiver: getAccount(MikoSeaMarket.getAdminAddress()).getCapability<&AnyResource{FungibleToken.Receiver}>(MIKOSEANFT.CollectionPublicPath),\n            cut: platfromFee,\n            description: \"Platform fee\"\n        )\n    ])\n}\n\npub fun getRoyaltiesV2(address: Address, nftID: UInt64): MetadataViews.Royalties {\n    let collectionRef = getAccount(address).getCapability<&{MIKOSEANFTV2.CollectionPublic}>(MIKOSEANFTV2.CollectionPublicPath).borrow() ?? panic(\"ACCOUNT_NOT_SETUP\")\n    let nft = collectionRef.borrowMIKOSEANFTV2(id: nftID) ?? panic(\"NFT_NOT_FOUND\")\n    return nft.getRoyaltiesMarket()\n}\n\ntransaction(nftID: UInt64, salePrice: UFix64, nftversion: String) {\n    let holderCap: Capability<&AnyResource{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>\n    let storefrontRef: &MikoSeaMarket.Storefront\n    let royalties: MetadataViews.Royalties\n    let nftType: Type\n\n    prepare(account: AuthAccount) {\n        pre {\n            nftversion == \"mikosea\" || nftversion == \"mikoseav2\": \"nftversion must be mikosea or mikoseav2\".concat(\", got \").concat(nftversion)\n        }\n\n        // setup account\n        // for MIKOSAENFTV2\n        if account.borrow<&MIKOSEANFTV2.Collection>(from: MIKOSEANFTV2.CollectionStoragePath) == nil {\n            let collection <- MIKOSEANFTV2.createEmptyCollection()\n            account.save(<-collection, to: MIKOSEANFTV2.CollectionStoragePath)\n        }\n        if (account.getCapability<&MIKOSEANFTV2.Collection{MIKOSEANFTV2.CollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Receiver,MetadataViews.ResolverCollection}>(MIKOSEANFTV2.CollectionPublicPath).borrow() == nil) {\n            account.unlink(MIKOSEANFTV2.CollectionPublicPath)\n            account.link<&MIKOSEANFTV2.Collection{MIKOSEANFTV2.CollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Receiver,MetadataViews.ResolverCollection}>(MIKOSEANFTV2.CollectionPublicPath, target: MIKOSEANFTV2.CollectionStoragePath)\n        }\n        // for MIKOSAENFT\n        if account.borrow<&MIKOSEANFT.Collection>(from: MIKOSEANFT.CollectionStoragePath) == nil {\n            let collection <- MIKOSEANFT.createEmptyCollection()\n            account.save(<-collection, to: MIKOSEANFT.CollectionStoragePath)\n        }\n        if (account.getCapability<&MIKOSEANFT.Collection{MIKOSEANFT.MikoSeaCollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Receiver,MetadataViews.ResolverCollection}>(MIKOSEANFT.CollectionPublicPath).borrow() == nil) {\n            account.unlink(MIKOSEANFT.CollectionPublicPath)\n            account.link<&MIKOSEANFT.Collection{MIKOSEANFT.MikoSeaCollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Receiver,MetadataViews.ResolverCollection}>(MIKOSEANFT.CollectionPublicPath, target: MIKOSEANFT.CollectionStoragePath)\n        }\n\n        // check and create storefront\n        if let storefrontRef = account.borrow<&MikoSeaMarket.Storefront>(from: MikoSeaMarket.MarketStoragePath) {\n            self.storefrontRef = storefrontRef\n        } else {\n            let storefront <- MikoSeaMarket.createStorefront()\n            let storefrontRef = &storefront as &MikoSeaMarket.Storefront\n            account.save(<-storefront, to: MikoSeaMarket.MarketStoragePath)\n            account.link<&MikoSeaMarket.Storefront{MikoSeaMarket.StorefrontPublic}>(MikoSeaMarket.MarketPublicPath, target: MikoSeaMarket.MarketStoragePath)\n            self.storefrontRef = storefrontRef\n        }\n\n        // validate nft\n        validateNftExpeiredDate(nftType: nftversion, address: account.address, nftID: nftID)\n\n        if nftversion == \"mikosea\" {\n            // get royalties\n            self.royalties = getRoyaltiesV1(address: account.address, nftID: nftID)\n\n            // link private collection\n            let MIKOSEANFTPrivatePath = /private/MIKOSEANFTCollection\n            if !account.getCapability<&MIKOSEANFT.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(MIKOSEANFTPrivatePath).check() {\n                account.link<&MIKOSEANFT.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(MIKOSEANFTPrivatePath, target: MIKOSEANFT.CollectionStoragePath)\n            }\n            self.holderCap = account.getCapability<&MIKOSEANFT.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(MIKOSEANFTPrivatePath)\n\n\n            // get nft type\n            self.nftType = Type<@MIKOSEANFT.NFT>()\n        } else {\n            // get royalties\n            self.royalties = getRoyaltiesV2(address: account.address, nftID: nftID)\n\n            // link private collection\n            let MIKOSEANFTV2PrivatePath = /private/MIKOSEANFTV2Collection\n            if !account.getCapability<&MIKOSEANFTV2.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(MIKOSEANFTV2PrivatePath).check() {\n                account.link<&MIKOSEANFTV2.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(MIKOSEANFTV2PrivatePath, target: MIKOSEANFTV2.CollectionStoragePath)\n            }\n            self.holderCap = account.getCapability<&MIKOSEANFTV2.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(MIKOSEANFTV2PrivatePath)\n\n\n            // get nft type\n            self.nftType = Type<@MIKOSEANFTV2.NFT>()\n\n            let holder = account.borrow<&MIKOSEANFTV2.Collection>(from: MIKOSEANFTV2.CollectionStoragePath)!\n            holder.setInMarket(nftID: nftID, value: true)\n        }\n    }\n\n    execute {\n        self.storefrontRef.createOrder(\n            nftType: self.nftType,\n            nftID: nftID,\n            holderCap: self.holderCap,\n            salePrice: salePrice,\n            royalties: self.royalties,\n            metadata: {}\n        )\n    }\n}\n",
+        "dependencies": {
+            "0xMIKOSEA_MARKET_ADDRESS": {
+                "MikoSeaMarket": {
+                    "testnet": {
+                        "address": "0x713306ac51ac7ddb",
+                        "contract": "MikoSeaMarket",
+                        "fq_address": "A.0x713306ac51ac7ddb.MikoSeaMarket",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138900314
+                    }
+                }
+            },
+            "0xMIKOSEA_MIKOSEANFT_ADDRESS": {
+                "MIKOSEANFT": {
+                    "testnet": {
+                        "address": "0x713306ac51ac7ddb",
+                        "contract": "MIKOSEANFT",
+                        "fq_address": "A.0x713306ac51ac7ddb.MIKOSEANFT",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138900430
+                    }
+                }
+            },
+            "0xMIKOSEA_MIKOSEANFTV2_ADDRESS": {
+                "MIKOSEANFTV2": {
+                    "testnet": {
+                        "address": "0x713306ac51ac7ddb",
+                        "contract": "MIKOSEANFTV2",
+                        "fq_address": "A.0x713306ac51ac7ddb.MIKOSEANFTV2",
+                        "pin": "bfeedef4b4548a7bab30ecf31c97eb781c67f2414b4913d5bb19e58aeebbc515",
+                        "pin_block_height": 138900589
+                    }
+                }
+            },
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138900591
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138900612
+                    }
+                }
+            },
+            "0xMETADATA_VIEWS_ADDRESS": {
+                "MetadataViews": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "MetadataViews",
+                        "fq_address": "A.0x631e88ae7f1d7c20.MetadataViews",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138900640
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "addr": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "nftID": {
+                "index": 1,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/mikoseamarket-remove-listing.json
+++ b/templates/Blocto/mikoseamarket-remove-listing.json
@@ -1,0 +1,97 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "2ab6cd52609847a308b14d629a800a09b07547d5c0f3080c541d9fe9d016943c",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "MikoSeaMarket Remove listing"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Remove listing"
+                }
+            }
+        },
+        "cadence": "import MikoSeaMarket from 0xMIKOSEA_MARKET_ADDRESS\nimport MIKOSEANFT from 0xMIKOSEA_MIKOSEANFT_ADDRESS\nimport MIKOSEANFTV2 from 0xMIKOSEA_MIKOSEANFTV2_ADDRESS\nimport FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport MetadataViews from 0xMETADATA_VIEWS_ADDRESS\n\npub fun getStorefront(_ account: AuthAccount): &MikoSeaMarket.Storefront {\n    if let storefrontRef = account.borrow<&MikoSeaMarket.Storefront>(from: MikoSeaMarket.MarketStoragePath) {\n        return storefrontRef\n    } else {\n        let storefront <- MikoSeaMarket.createStorefront()\n\n        let storefrontRef = &storefront as &MikoSeaMarket.Storefront\n\n        account.save(<-storefront, to: MikoSeaMarket.MarketStoragePath)\n\n        account.link<&MikoSeaMarket.Storefront{MikoSeaMarket.StorefrontPublic}>(MikoSeaMarket.MarketPublicPath, target: MikoSeaMarket.MarketStoragePath)\n\n        return storefrontRef\n    }\n}\n\ntransaction(listingID: UInt64) {\n    let storefrontRef: &MikoSeaMarket.Storefront\n\n    prepare(account: AuthAccount) {\n        // check and remove storefront\n        self.storefrontRef = getStorefront(account)\n    }\n\n    execute {\n        self.storefrontRef.removeOrder(listingID)\n    }\n}",
+        "dependencies": {
+            "0xMIKOSEA_MARKET_ADDRESS": {
+                "MikoSeaMarket": {
+                    "testnet": {
+                        "address": "0x713306ac51ac7ddb",
+                        "contract": "MikoSeaMarket",
+                        "fq_address": "A.0x713306ac51ac7ddb.MikoSeaMarket",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138900341
+                    }
+                }
+            },
+            "0xMIKOSEA_MIKOSEANFT_ADDRESS": {
+                "MIKOSEANFT": {
+                    "testnet": {
+                        "address": "0x713306ac51ac7ddb",
+                        "contract": "MIKOSEANFT",
+                        "fq_address": "A.0x713306ac51ac7ddb.MIKOSEANFT",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138900470
+                    }
+                }
+            },
+            "0xMIKOSEA_MIKOSEANFTV2_ADDRESS": {
+                "MIKOSEANFTV2": {
+                    "testnet": {
+                        "address": "0x713306ac51ac7ddb",
+                        "contract": "MIKOSEANFTV2",
+                        "fq_address": "A.0x713306ac51ac7ddb.MIKOSEANFTV2",
+                        "pin": "bfeedef4b4548a7bab30ecf31c97eb781c67f2414b4913d5bb19e58aeebbc515",
+                        "pin_block_height": 138900589
+                    }
+                }
+            },
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138900592
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138900612
+                    }
+                }
+            },
+            "0xMETADATA_VIEWS_ADDRESS": {
+                "MetadataViews": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "MetadataViews",
+                        "fq_address": "A.0x631e88ae7f1d7c20.MetadataViews",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138900640
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "account": {
+                "index": 0,
+                "type": "AuthAccount",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/mikoseanftv2-batch-create-comment.json
+++ b/templates/Blocto/mikoseanftv2-batch-create-comment.json
@@ -1,0 +1,47 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ca903504a6397b24425a38989a85a0c3327392b050cea48ea8cc8789fe7a303f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "mikoseanftv2 Batch create comment"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Create comment"
+                }
+            }
+        },
+        "cadence": "import MIKOSEANFTV2 from 0xMIKOSEA_MIKOSEANFTV2_ADDRESS\n\ntransaction(nftIDs: [UInt64], comment: String) {\n    let holder: &MIKOSEANFTV2.Collection\n\n    prepare(signer: AuthAccount) {\n        self.holder = signer.borrow<&MIKOSEANFTV2.Collection>(from: MIKOSEANFTV2.CollectionStoragePath) ?? panic(\"NOT_SETUP\")\n    }\n\n    execute {\n        for nftID in nftIDs {\n            self.holder.createComment(nftID: nftID, comment: comment)\n        }\n    }\n}",
+        "dependencies": {
+            "0xMIKOSEA_MIKOSEANFTV2_ADDRESS": {
+                "MIKOSEANFTV2": {
+                    "testnet": {
+                        "address": "0x713306ac51ac7ddb",
+                        "contract": "MIKOSEANFTV2",
+                        "fq_address": "A.0x713306ac51ac7ddb.MIKOSEANFTV2",
+                        "pin": "bfeedef4b4548a7bab30ecf31c97eb781c67f2414b4913d5bb19e58aeebbc515",
+                        "pin_block_height": 138900375
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "nftIDs": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "comment": {
+                "index": 1,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/mikoseanftv2-transfer-and-check-market.json
+++ b/templates/Blocto/mikoseanftv2-transfer-and-check-market.json
@@ -1,0 +1,69 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "3fd9c6ce275a63ed03ca38aef768b15d9658fde55789f1578bd2c4d2492682a0",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "mikoseanftv2 Transfer and check market"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Transfer NFT"
+                }
+            }
+        },
+        "cadence": "import MIKOSEANFTV2 from 0xMIKOSEA_MIKOSEANFTV2_ADDRESS\nimport MikoSeaMarket from 0xMIKOSEA_MARKET_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\n\npub fun checkMarket(acct: AuthAccount, nftID: UInt64) {\n    if let storefrontRef = acct.borrow<&MikoSeaMarket.Storefront>(from: MikoSeaMarket.MarketStoragePath) {\n        for order in storefrontRef.getOrders() {\n            if order.nftType == Type<@MIKOSEANFTV2.NFT>() && order.nftID == nftID && (order.status == \"created\" || order.status == \"validated\") {\n                panic(\"NFT_IS_IN_LISTING\")\n            }\n        }\n    }\n}\ntransaction(nftID: UInt64, recipient: Address) {\n    let holder: &MIKOSEANFTV2.Collection\n    let recipientRef: &AnyResource{MIKOSEANFTV2.CollectionPublic}\n\n    prepare(signer: AuthAccount) {\n        self.holder = signer.borrow<&MIKOSEANFTV2.Collection>(from: MIKOSEANFTV2.CollectionStoragePath) ?? panic(\"NOT_SETUP\")\n\n        self.recipientRef = getAccount(recipient).getCapability<&{MIKOSEANFTV2.CollectionPublic}>(MIKOSEANFTV2.CollectionPublicPath).borrow() ?? panic(\"NOT_SETUP\")\n        checkMarket(acct: signer, nftID: nftID)\n    }\n\n    execute {\n        self.holder.transfer(nftID: nftID, recipient: self.recipientRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMIKOSEA_MIKOSEANFTV2_ADDRESS": {
+                "MIKOSEANFTV2": {
+                    "testnet": {
+                        "address": "0x713306ac51ac7ddb",
+                        "contract": "MIKOSEANFTV2",
+                        "fq_address": "A.0x713306ac51ac7ddb.MIKOSEANFTV2",
+                        "pin": "bfeedef4b4548a7bab30ecf31c97eb781c67f2414b4913d5bb19e58aeebbc515",
+                        "pin_block_height": 138900406
+                    }
+                }
+            },
+            "0xMIKOSEA_MARKET_ADDRESS": {
+                "MikoSeaMarket": {
+                    "testnet": {
+                        "address": "0x713306ac51ac7ddb",
+                        "contract": "MikoSeaMarket",
+                        "fq_address": "A.0x713306ac51ac7ddb.MikoSeaMarket",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138900528
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138900557
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "acct": {
+                "index": 0,
+                "type": "AuthAccount",
+                "messages": {}
+            },
+            "nftID": {
+                "index": 1,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/musicblock-borrow-money-by-nft.json
+++ b/templates/Blocto/musicblock-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "bd8d7b0df0897d05262715aac29748cdd501b595b4c00952b2a63f2bc48a2428",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "MusicBlock Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MusicBlockCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889793
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889821
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889905
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889929
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/musicblock-cancel-borrow-money.json
+++ b/templates/Blocto/musicblock-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "becbac043bd7b7ceda8e77aaf7004128e31b28f13978451690f05c3e974952f1",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "MusicBlock Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MusicBlockCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889805
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889871
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/musicblock-force-redeem.json
+++ b/templates/Blocto/musicblock-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "136463c0fde1482319bb802f194425720bfec22c9cef88233cb1365cd374ff9c",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "MusicBlock Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MusicBlockCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889835
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889905
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/musicblock-lend-money.json
+++ b/templates/Blocto/musicblock-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "1f2c0ac7087295a7abfefb2b6c653e36485750e3fbf66e46b0cd012999b59463",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "MusicBlock Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889915
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889932
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/musicblock-repay.json
+++ b/templates/Blocto/musicblock-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "3b554ce94e573745497ad489dc50fabc213350bec4e801bf0383dee11ef57a95",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "MusicBlock Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MusicBlockCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889915
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890023
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890030
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/mynft-borrow-money-by-nft.json
+++ b/templates/Blocto/mynft-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "33499eb0d6ce6391c3e47c96cdbcbf99c1826c54f27ff4d01d71d40d9c070fc9",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Mynft Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MynftCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889551
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889575
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889646
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889671
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/mynft-cancel-borrow-money.json
+++ b/templates/Blocto/mynft-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "eb92d826be504969e4ed5f7ccde469c22b613be0d85f37b800e5a06df064e0e6",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Mynft Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MynftCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889597
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889671
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/mynft-force-redeem.json
+++ b/templates/Blocto/mynft-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "b5e308d6bd6edfcd2e985d04d3b20cc2596b2334c7b81989792e32a20926d486",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Mynft Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MynftCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889597
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889669
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/mynft-lend-money.json
+++ b/templates/Blocto/mynft-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "8c032e988ee444063b37c5b0fda7e035204f104748ba55b13058a89b016ceb66",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Mynft Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889669
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889707
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/mynft-repay.json
+++ b/templates/Blocto/mynft-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "870a0130f78a53ce497ec0b34525af8fd99f64c2cfda5bdadc2d7715f47c2827",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Mynft Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MynftCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889669
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138889720
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138889781
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/nyatheesovo-borrow-money-by-nft.json
+++ b/templates/Blocto/nyatheesovo-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "f4c20028382f111b23dd2d36b3a13a2293b39163a7fe55f7c0f49c1cb902be21",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "NyatheesOVO Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/NyatheesOVOCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889928
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889952
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890023
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890030
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/nyatheesovo-cancel-borrow-money.json
+++ b/templates/Blocto/nyatheesovo-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "183a5895a450243754026bfe9bfeb3c9845100319bd796629712e27db474d5ef",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "NyatheesOVO Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/NyatheesOVOCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889928
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890025
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/nyatheesovo-force-redeem.json
+++ b/templates/Blocto/nyatheesovo-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "0532b0215546666335092b674182945fd084b820f8879700cce2bf3e05b77b91",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "NyatheesOVO Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/NyatheesOVOCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138889958
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890025
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/nyatheesovo-lend-money.json
+++ b/templates/Blocto/nyatheesovo-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "489a609d4c240c94da860e1509a1811843432b3262457f7010c73d272817e750",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "NyatheesOVO Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890025
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890062
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/nyatheesovo-repay.json
+++ b/templates/Blocto/nyatheesovo-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "d83e5a921c197e56bec53d055715d1bbf4ff0b76e11d8764d1919463507c81b8",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "NyatheesOVO Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/NyatheesOVOCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890041
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890137
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890163
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/raceday_nft-borrow-money-by-nft.json
+++ b/templates/Blocto/raceday_nft-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "926b91ecf210af46deab516f7278b9afe46395427e7dfe3c6d355b5b6514671f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "RaceDay_NFT Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/RaceDay_NFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890041
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890076
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890163
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890192
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/raceday_nft-cancel-borrow-money.json
+++ b/templates/Blocto/raceday_nft-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "1133fcb233cf5a7faa86a2222209009fc215963985e980b12ae25d98459198de",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "RaceDay_NFT Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/RaceDay_NFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890062
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890148
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/raceday_nft-force-redeem.json
+++ b/templates/Blocto/raceday_nft-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "973e273d1d80d07f71c960bb2fa385ac4b6fe03bf2f1f5ce9b8b1442eb4f24ca",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "RaceDay_NFT Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/RaceDay_NFTCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890062
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890149
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/raceday_nft-lend-money.json
+++ b/templates/Blocto/raceday_nft-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "422ec6f1805e088f1fe372e3322a02211c644606f2d9f5077fa1b82abf934f87",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "RaceDay_NFT Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890148
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890164
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/raceday_nft-repay.json
+++ b/templates/Blocto/raceday_nft-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "109d16de8d54c941bc2e2b7d6597dece8b8424aa290ee37f195cf0fcd79e4cd7",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "RaceDay_NFT Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/RaceDay_NFTCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890163
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890244
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890276
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/staking-stake.json
+++ b/templates/Blocto/staking-stake.json
@@ -1,0 +1,86 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "7974b1cf73751dc1c09adefa30d956f51a2cf32f646927009fc1a9282cb37f8b",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "staking Stake"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Stake {amount} STARLY tokens"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport MetadataViews from 0xMETADATA_VIEWS_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport StarlyToken from 0xSTARLY_TOKEN_ADDRESS\nimport StarlyTokenStaking from 0xSTARLY_TOKEN_STAKING_ADDRESS\n\ntransaction(amount: UFix64) {\n    let vaultRef: &StarlyToken.Vault\n    let stakeCollectionRef: &StarlyTokenStaking.Collection\n\n    prepare(acct: AuthAccount) {\n        self.vaultRef = acct.borrow<&StarlyToken.Vault>(from: StarlyToken.TokenStoragePath)\n            ?? panic(\"Could not borrow reference to the owner's StarlyToken vault!\")\n\n        if acct.borrow<&StarlyTokenStaking.Collection>(from: StarlyTokenStaking.CollectionStoragePath) == nil {\n            acct.save(<-StarlyTokenStaking.createEmptyCollection(), to: StarlyTokenStaking.CollectionStoragePath)\n            acct.link<&StarlyTokenStaking.Collection{NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection, StarlyTokenStaking.CollectionPublic}>(\n                StarlyTokenStaking.CollectionPublicPath,\n                target: StarlyTokenStaking.CollectionStoragePath)\n        }\n        self.stakeCollectionRef = acct.borrow<&StarlyTokenStaking.Collection>(from: StarlyTokenStaking.CollectionStoragePath)\n            ?? panic(\"Could not borrow reference to the owner's StarlyTokenStaking collection!\")\n    }\n\n    execute {\n        let vault <- self.vaultRef.withdraw(amount: amount) as! @StarlyToken.Vault\n        self.stakeCollectionRef.stake(principalVault: <-vault)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138897944
+                    }
+                }
+            },
+            "0xMETADATA_VIEWS_ADDRESS": {
+                "MetadataViews": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "MetadataViews",
+                        "fq_address": "A.0x631e88ae7f1d7c20.MetadataViews",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138897979
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138897999
+                    }
+                }
+            },
+            "0xSTARLY_TOKEN_ADDRESS": {
+                "StarlyToken": {
+                    "testnet": {
+                        "address": "0xf63219072aaddd50",
+                        "contract": "StarlyToken",
+                        "fq_address": "A.0xf63219072aaddd50.StarlyToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898006
+                    }
+                }
+            },
+            "0xSTARLY_TOKEN_STAKING_ADDRESS": {
+                "StarlyTokenStaking": {
+                    "testnet": {
+                        "address": "0x8d1cf508d398c5c2",
+                        "contract": "StarlyTokenStaking",
+                        "fq_address": "A.0x8d1cf508d398c5c2.StarlyTokenStaking",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138898128
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/staking-unstake.json
+++ b/templates/Blocto/staking-unstake.json
@@ -1,0 +1,75 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "1c61b988f65b271f33b49dde0fe26fe3a9d64cdf9b17b689cc4bca31da539e56",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "staking Unstake"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unstake stake #{stakeID}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport StarlyToken from 0xSTARLY_TOKEN_ADDRESS\nimport StarlyTokenStaking from 0xSTARLY_TOKEN_STAKING_ADDRESS\n\ntransaction(stakeID: UInt64) {\n    let vaultRef: &StarlyToken.Vault\n    let stakeCollectionRef: &StarlyTokenStaking.Collection\n\n    prepare(acct: AuthAccount) {\n        self.vaultRef = acct.borrow<&StarlyToken.Vault>(from: StarlyToken.TokenStoragePath)\n            ?? panic(\"Could not borrow reference to the owner's StarlyToken vault!\")\n\n        self.stakeCollectionRef = acct.borrow<&StarlyTokenStaking.Collection>(from: StarlyTokenStaking.CollectionStoragePath)\n            ?? panic(\"Could not borrow reference to the owner's StarlyTokenStaking collection!\")\n    }\n\n    execute {\n        self.vaultRef.deposit(from: <-self.stakeCollectionRef.unstake(id: stakeID))\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898006
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898045
+                    }
+                }
+            },
+            "0xSTARLY_TOKEN_ADDRESS": {
+                "StarlyToken": {
+                    "testnet": {
+                        "address": "0xf63219072aaddd50",
+                        "contract": "StarlyToken",
+                        "fq_address": "A.0xf63219072aaddd50.StarlyToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898083
+                    }
+                }
+            },
+            "0xSTARLY_TOKEN_STAKING_ADDRESS": {
+                "StarlyTokenStaking": {
+                    "testnet": {
+                        "address": "0x8d1cf508d398c5c2",
+                        "contract": "StarlyTokenStaking",
+                        "fq_address": "A.0x8d1cf508d398c5c2.StarlyTokenStaking",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138898213
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "stakeID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/starly-accept-sale-offer-v2.json
+++ b/templates/Blocto/starly-accept-sale-offer-v2.json
@@ -1,0 +1,113 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "918da4f4f8041b6de04b20d42fcf887c2821959bedbf3e2d62df00220ebc588d",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Starly Accept sale offer v2"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Starly NFT #{itemID} from {marketCollectionAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport FlowStorageFees from 0xFLOW_STORAGE_FEES_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport StarlyCard from 0xSTARLY_CARD_ADDRESS\nimport StarlyCardMarket from 0xSTARLY_CARD_MARKET_ADDRESS\n\ntransaction(itemID: UInt64, marketCollectionAddress: Address) {\n    prepare(signer: AuthAccount, admin: AuthAccount) {\n        let marketCollection = getAccount(marketCollectionAddress)\n            .getCapability<&StarlyCardMarket.Collection{StarlyCardMarket.CollectionPublic}>(\n                StarlyCardMarket.CollectionPublicPath\n            )!\n            .borrow()\n            ?? panic(\"Could not borrow market collection from market address\")\n\n        let saleItem = marketCollection.borrowSaleItem(itemID: itemID)\n                    ?? panic(\"No item with that ID\")\n        let price = saleItem.price\n\n        let mainFUSDVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault)\n            ?? panic(\"Cannot borrow FUSD vault from acct storage\")\n        let paymentVault <- mainFUSDVault.withdraw(amount: price)\n\n        let starlyCardCollection = signer.borrow<&StarlyCard.Collection{NonFungibleToken.Receiver}>(\n            from: StarlyCard.CollectionStoragePath\n        ) ?? panic(\"Cannot borrow StarlyCard collection receiver from acct\")\n\n        marketCollection.purchase(\n            itemID: itemID,\n            buyerCollection: starlyCardCollection,\n            buyerPayment: <- paymentVault,\n            buyerAddress: signer.address\n        )\n\n        fun returnFlowFromStorage(_ storage: UInt64): UFix64 {\n            let f = UFix64(storage % 100000000 as UInt64) * 0.00000001 as UFix64 + UFix64(storage / 100000000 as UInt64)\n            let storageMb = f * 100.0 as UFix64\n            let storage = FlowStorageFees.storageCapacityToFlow(storageMb)\n            return storage\n        }\n\n        var storageUsed = returnFlowFromStorage(signer.storageUsed)\n        var storageTotal = returnFlowFromStorage(signer.storageCapacity)\n        if (storageUsed > storageTotal) {\n            let difference = storageUsed - storageTotal\n            let vaultRef = admin.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n                ?? panic(\"Could not borrow reference to the admin's Vault!\")\n            let sentVault <- vaultRef.withdraw(amount: difference)\n            let receiver = signer.getCapability(/public/flowTokenReceiver).borrow<&{FungibleToken.Receiver}>()\n                ?? panic(\"failed to borrow reference to recipient vault\")\n            receiver.deposit(from: <-sentVault)\n        }\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890791
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890828
+                    }
+                }
+            },
+            "0xFLOW_STORAGE_FEES_ADDRESS": {
+                "FlowStorageFees": {
+                    "testnet": {
+                        "address": "0x8c5303eaa26202d6",
+                        "contract": "FlowStorageFees",
+                        "fq_address": "A.0x8c5303eaa26202d6.FlowStorageFees",
+                        "pin": "ec7be5050256b8b9ab2a6f5550a42b6a64627fa7e684a88de5dd767864f0471a",
+                        "pin_block_height": 138890860
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890890
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890926
+                    }
+                }
+            },
+            "0xSTARLY_CARD_ADDRESS": {
+                "StarlyCard": {
+                    "testnet": {
+                        "address": "0x697d72a988a77070",
+                        "contract": "StarlyCard",
+                        "fq_address": "A.0x697d72a988a77070.StarlyCard",
+                        "pin": "455a9a9d9530fe73aeba8c3f857fce0ad33438592943e4b391a6b92418cce5e8",
+                        "pin_block_height": 138891139
+                    }
+                }
+            },
+            "0xSTARLY_CARD_MARKET_ADDRESS": {
+                "StarlyCardMarket": {
+                    "testnet": {
+                        "address": "0x697d72a988a77070",
+                        "contract": "StarlyCardMarket",
+                        "fq_address": "A.0x697d72a988a77070.StarlyCardMarket",
+                        "pin": "29a94f46acbcd90cca98bdd1bb3e1cbe84d2c9c51367f391fb9d94e352626daf",
+                        "pin_block_height": 138891423
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "itemID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "marketCollectionAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/starly-accept-sale-offer-with-auto-swap.json
+++ b/templates/Blocto/starly-accept-sale-offer-with-auto-swap.json
@@ -1,0 +1,124 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "a233508c6e4c0b80e617aac6d3d6cb126022b8e1c29fbed9d44e5075890f90e2",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Starly Accept sale offer with auto swap"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Starly NFT #{itemID} from {marketCollectionAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport FlowSwapPair from 0xFLOW_USDT_SWAP_ADDRESS\nimport FusdUsdtSwapPair from 0xFUSD_USDT_SWAP_ADDRESS\nimport StarlyCard from 0xSTARLY_CARD_ADDRESS\nimport StarlyCardMarket from 0xSTARLY_CARD_MARKET_ADDRESS\n\ntransaction(itemID: UInt64, marketCollectionAddress: Address) {\n    let paymentVault: @FungibleToken.Vault\n    let starlyCardCollection: &StarlyCard.Collection{NonFungibleToken.Receiver}\n    let marketCollection: &StarlyCardMarket.Collection{StarlyCardMarket.CollectionPublic}\n    let buyerAddress: Address\n\n    prepare(signer: AuthAccount) {\n        self.buyerAddress = signer.address;\n\n        self.starlyCardCollection = signer.borrow<&StarlyCard.Collection{NonFungibleToken.Receiver}>(\n            from: StarlyCard.CollectionStoragePath\n        ) ?? panic(\"Cannot borrow StarlyCard collection receiver from acct\")\n\n        self.marketCollection = getAccount(marketCollectionAddress)\n            .getCapability<&StarlyCardMarket.Collection{StarlyCardMarket.CollectionPublic}>(\n                StarlyCardMarket.CollectionPublicPath\n            )!\n            .borrow()\n            ?? panic(\"Could not borrow market collection from market address\")\n\n        let saleItem = self.marketCollection.borrowSaleItem(itemID: itemID)\n                    ?? panic(\"No item with that ID\")\n\n        let fusdPrice = saleItem.price\n\n        let amountUsdt = FusdUsdtSwapPair.quoteSwapToken2ForExactToken1(amount: fusdPrice)\n        let amountFlow = FlowSwapPair.quoteSwapToken1ForExactToken2(amount: amountUsdt) / (1.0 - FlowSwapPair.feePercentage) + 0.00001\n\n        // swap Flow to FUSD\n        let flowVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n          ?? panic(\"Could not borrow a reference to Vault\")\n\n        let token1Vault <- flowVault.withdraw(amount: amountFlow) as! @FlowToken.Vault\n        let token2Vault <- FlowSwapPair.swapToken1ForToken2(from: <-token1Vault)\n        let token3Vault <- FusdUsdtSwapPair.swapToken2ForToken1(from: <-token2Vault)\n\n        if signer.borrow<&FUSD.Vault>(from: /storage/fusdVault) == nil {\n            // Create a new FUSD Vault and put it in storage\n            signer.save(<-FUSD.createEmptyVault(), to: /storage/fusdVault)\n\n            // Create a public capability to the Vault that only exposes\n            // the deposit function through the Receiver interface\n            signer.link<&FUSD.Vault{FungibleToken.Receiver}>(\n                /public/fusdReceiver,\n                target: /storage/fusdVault\n            )\n\n            // Create a public capability to the Vault that only exposes\n            // the balance field through the Balance interface\n            signer.link<&FUSD.Vault{FungibleToken.Balance}>(\n                /public/fusdBalance,\n                target: /storage/fusdVault\n            )\n        }\n\n        let fusdVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault)\n            ?? panic(\"Could not borrow a reference to Vault\")\n\n        fusdVault.deposit(from: <- token3Vault)\n        self.paymentVault <- fusdVault.withdraw(amount: fusdPrice)\n    }\n\n    execute {\n        self.marketCollection.purchase(\n            itemID: itemID,\n            buyerCollection: self.starlyCardCollection,\n            buyerPayment: <- self.paymentVault,\n            buyerAddress: self.buyerAddress\n        )\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890794
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890828
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890835
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890861
+                    }
+                }
+            },
+            "0xFLOW_USDT_SWAP_ADDRESS": {
+                "FlowSwapPair": {
+                    "testnet": {
+                        "address": "0xd9854329b7edf136",
+                        "contract": "FlowSwapPair",
+                        "fq_address": "A.0xd9854329b7edf136.FlowSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138890933
+                    }
+                }
+            },
+            "0xFUSD_USDT_SWAP_ADDRESS": {
+                "FusdUsdtSwapPair": {
+                    "testnet": {
+                        "address": "0x3502a5dacaf350bb",
+                        "contract": "FusdUsdtSwapPair",
+                        "fq_address": "A.0x3502a5dacaf350bb.FusdUsdtSwapPair",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138891042
+                    }
+                }
+            },
+            "0xSTARLY_CARD_ADDRESS": {
+                "StarlyCard": {
+                    "testnet": {
+                        "address": "0x697d72a988a77070",
+                        "contract": "StarlyCard",
+                        "fq_address": "A.0x697d72a988a77070.StarlyCard",
+                        "pin": "455a9a9d9530fe73aeba8c3f857fce0ad33438592943e4b391a6b92418cce5e8",
+                        "pin_block_height": 138891252
+                    }
+                }
+            },
+            "0xSTARLY_CARD_MARKET_ADDRESS": {
+                "StarlyCardMarket": {
+                    "testnet": {
+                        "address": "0x697d72a988a77070",
+                        "contract": "StarlyCardMarket",
+                        "fq_address": "A.0x697d72a988a77070.StarlyCardMarket",
+                        "pin": "29a94f46acbcd90cca98bdd1bb3e1cbe84d2c9c51367f391fb9d94e352626daf",
+                        "pin_block_height": 138891523
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "itemID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "marketCollectionAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/starly-accept-sale-offer.json
+++ b/templates/Blocto/starly-accept-sale-offer.json
@@ -1,0 +1,91 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "1b46c6a257397f7dddd60a2cb048e785d348e24422eb1167ee2f090e65a99b8a",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Starly Accept sale offer"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Starly NFT #{itemID} from {marketCollectionAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport StarlyCard from 0xSTARLY_CARD_ADDRESS\nimport StarlyCardMarket from 0xSTARLY_CARD_MARKET_ADDRESS\n\ntransaction(itemID: UInt64, marketCollectionAddress: Address) {\n    let paymentVault: @FungibleToken.Vault\n    let starlyCardCollection: &StarlyCard.Collection{NonFungibleToken.Receiver}\n    let marketCollection: &StarlyCardMarket.Collection{StarlyCardMarket.CollectionPublic}\n    let buyerAddress: Address\n\n    prepare(signer: AuthAccount) {\n        self.buyerAddress = signer.address;\n        self.marketCollection = getAccount(marketCollectionAddress)\n            .getCapability<&StarlyCardMarket.Collection{StarlyCardMarket.CollectionPublic}>(\n                StarlyCardMarket.CollectionPublicPath\n            )!\n            .borrow()\n            ?? panic(\"Could not borrow market collection from market address\")\n\n        let saleItem = self.marketCollection.borrowSaleItem(itemID: itemID)\n                    ?? panic(\"No item with that ID\")\n        let price = saleItem.price\n\n        let mainFUSDVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault)\n            ?? panic(\"Cannot borrow FUSD vault from acct storage\")\n        self.paymentVault <- mainFUSDVault.withdraw(amount: price)\n\n        self.starlyCardCollection = signer.borrow<&StarlyCard.Collection{NonFungibleToken.Receiver}>(\n            from: StarlyCard.CollectionStoragePath\n        ) ?? panic(\"Cannot borrow StarlyCard collection receiver from acct\")\n    }\n\n    execute {\n        self.marketCollection.purchase(\n            itemID: itemID,\n            buyerCollection: self.starlyCardCollection,\n            buyerPayment: <- self.paymentVault,\n            buyerAddress: self.buyerAddress\n        )\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890777
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890790
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890830
+                    }
+                }
+            },
+            "0xSTARLY_CARD_ADDRESS": {
+                "StarlyCard": {
+                    "testnet": {
+                        "address": "0x697d72a988a77070",
+                        "contract": "StarlyCard",
+                        "fq_address": "A.0x697d72a988a77070.StarlyCard",
+                        "pin": "455a9a9d9530fe73aeba8c3f857fce0ad33438592943e4b391a6b92418cce5e8",
+                        "pin_block_height": 138891004
+                    }
+                }
+            },
+            "0xSTARLY_CARD_MARKET_ADDRESS": {
+                "StarlyCardMarket": {
+                    "testnet": {
+                        "address": "0x697d72a988a77070",
+                        "contract": "StarlyCardMarket",
+                        "fq_address": "A.0x697d72a988a77070.StarlyCardMarket",
+                        "pin": "29a94f46acbcd90cca98bdd1bb3e1cbe84d2c9c51367f391fb9d94e352626daf",
+                        "pin_block_height": 138891316
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "itemID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "marketCollectionAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/starly-buy-pack.json
+++ b/templates/Blocto/starly-buy-pack.json
@@ -1,0 +1,105 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "abceec7c6efc86df3072c965e98ac2f821836f8b319f505f3337b4ad0f0e124f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Starly Buy pack"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Starly pack(s) for {price} FUSD"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport FUSD from 0xFUSD_ADDRESS\nimport StarlyCardMarket from 0xSTARLY_CARD_MARKET_ADDRESS\nimport StarlyPack from 0xSTARLY_PACK_ADDRESS\n\ntransaction(\n    collectionID: String,\n    packIDs: [String],\n    price: UFix64,\n    beneficiaryAddress: Address,\n    beneficiaryCutPercent: UFix64,\n    creatorAddress: Address,\n    creatorCutPercent: UFix64) {\n\n    let paymentVault: @FungibleToken.Vault\n    let beneficiaryFUSDVault: Capability<&FUSD.Vault{FungibleToken.Receiver}>\n    let creatorFUSDVault: Capability<&FUSD.Vault{FungibleToken.Receiver}>\n    let buyerAddress: Address\n\n    prepare(signer: AuthAccount) {\n        self.buyerAddress = signer.address;\n        let buyerFUSDVault = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault)\n            ?? panic(\"Cannot borrow FUSD vault from acct storage\")\n        self.paymentVault <- buyerFUSDVault.withdraw(amount: price)\n\n        let beneficiary = getAccount(beneficiaryAddress);\n        self.beneficiaryFUSDVault = beneficiary.getCapability<&FUSD.Vault{FungibleToken.Receiver}>(/public/fusdReceiver)!\n        assert(self.beneficiaryFUSDVault.borrow() != nil, message: \"Missing or mis-typed FUSD receiver (beneficiary)\")\n\n        let creator = getAccount(creatorAddress)\n        self.creatorFUSDVault = creator.getCapability<&FUSD.Vault{FungibleToken.Receiver}>(/public/fusdReceiver)!\n        assert(self.creatorFUSDVault.borrow() != nil, message: \"Missing or mis-typed FUSD receiver (creator)\")\n    }\n\n    execute {\n        StarlyPack.purchase(\n            collectionID: collectionID,\n            packIDs: packIDs,\n            price: price,\n            buyerAddress: self.buyerAddress,\n            paymentVault: <- self.paymentVault,\n            beneficiarySaleCutReceiver: StarlyCardMarket.SaleCutReceiver(\n                receiver: self.beneficiaryFUSDVault,\n                percent: beneficiaryCutPercent),\n            creatorSaleCutReceiver: StarlyCardMarket.SaleCutReceiver(\n                receiver: self.creatorFUSDVault,\n                percent: creatorCutPercent),\n            additionalSaleCutReceivers: [])\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890868
+                    }
+                }
+            },
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890918
+                    }
+                }
+            },
+            "0xSTARLY_CARD_MARKET_ADDRESS": {
+                "StarlyCardMarket": {
+                    "testnet": {
+                        "address": "0x697d72a988a77070",
+                        "contract": "StarlyCardMarket",
+                        "fq_address": "A.0x697d72a988a77070.StarlyCardMarket",
+                        "pin": "29a94f46acbcd90cca98bdd1bb3e1cbe84d2c9c51367f391fb9d94e352626daf",
+                        "pin_block_height": 138891190
+                    }
+                }
+            },
+            "0xSTARLY_PACK_ADDRESS": {
+                "StarlyPack": {
+                    "testnet": {
+                        "address": "0x697d72a988a77070",
+                        "contract": "StarlyPack",
+                        "fq_address": "A.0x697d72a988a77070.StarlyPack",
+                        "pin": "c5628184f286614e9f69b3101cef7b988fc42736f51907afdc62a0ca2d829574",
+                        "pin_block_height": 138891512
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "collectionID": {
+                "index": 0,
+                "type": "String",
+                "messages": {}
+            },
+            "packIDs": {
+                "index": 1,
+                "type": "String",
+                "messages": {}
+            },
+            "price": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "beneficiaryAddress": {
+                "index": 3,
+                "type": "Address",
+                "messages": {}
+            },
+            "beneficiaryCutPercent": {
+                "index": 4,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "creatorAddress": {
+                "index": 5,
+                "type": "Address",
+                "messages": {}
+            },
+            "creatorCutPercent": {
+                "index": 6,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/starly-cancel-sale-offer.json
+++ b/templates/Blocto/starly-cancel-sale-offer.json
@@ -1,0 +1,42 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "d02ef217e3b23d41ddc67f25f7fee715bc27469f79ff96e7c18f966f33204088",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Starly Cancel sale offer"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Remove Starly NFT #{itemID} from sale"
+                }
+            }
+        },
+        "cadence": "import StarlyCardMarket from 0xSTARLY_CARD_MARKET_ADDRESS\n\ntransaction(itemID: UInt64) {\n    prepare(account: AuthAccount) {\n        let offer <- account\n          .borrow<&StarlyCardMarket.Collection>(from: StarlyCardMarket.CollectionStoragePath)!\n          .remove(itemID: itemID)\n        destroy offer\n    }\n}\n",
+        "dependencies": {
+            "0xSTARLY_CARD_MARKET_ADDRESS": {
+                "StarlyCardMarket": {
+                    "testnet": {
+                        "address": "0x697d72a988a77070",
+                        "contract": "StarlyCardMarket",
+                        "fq_address": "A.0x697d72a988a77070.StarlyCardMarket",
+                        "pin": "29a94f46acbcd90cca98bdd1bb3e1cbe84d2c9c51367f391fb9d94e352626daf",
+                        "pin_block_height": 138891674
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "itemID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/starly-initialize-starly-token.json
+++ b/templates/Blocto/starly-initialize-starly-token.json
@@ -1,0 +1,53 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "e63444b893381c7e7546adde0761ade93dee00082cd739b38e73da067eeb7235",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Starly Initialize starly token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Initialize your account for $STARLY token"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport StarlyToken from 0xSTARLY_TOKEN_ADDRESS\n\npub fun hasStarlyToken(_ address: Address): Bool {\n    let receiver: Bool = getAccount(address)\n        .getCapability<&StarlyToken.Vault{FungibleToken.Receiver}>(StarlyToken.TokenPublicReceiverPath)\n        .check()\n\n    let balance: Bool = getAccount(address)\n        .getCapability<&StarlyToken.Vault{FungibleToken.Balance}>(StarlyToken.TokenPublicBalancePath)\n        .check()\n\n    return receiver && balance\n}\n\ntransaction {\n    prepare(acct: AuthAccount) {\n        if !hasStarlyToken(acct.address) {\n            if acct.borrow<&StarlyToken.Vault>(from: StarlyToken.TokenStoragePath) == nil {\n                acct.save(<-StarlyToken.createEmptyVault(), to: StarlyToken.TokenStoragePath)\n            }\n            acct.unlink(StarlyToken.TokenPublicReceiverPath)\n            acct.unlink(StarlyToken.TokenPublicBalancePath)\n            acct.link<&StarlyToken.Vault{FungibleToken.Receiver}>(\n                StarlyToken.TokenPublicReceiverPath,\n                target: StarlyToken.TokenStoragePath)\n            acct.link<&StarlyToken.Vault{FungibleToken.Balance}>(\n                StarlyToken.TokenPublicBalancePath,\n                target: StarlyToken.TokenStoragePath)\n        }\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138895197
+                    }
+                }
+            },
+            "0xSTARLY_TOKEN_ADDRESS": {
+                "StarlyToken": {
+                    "testnet": {
+                        "address": "0xf63219072aaddd50",
+                        "contract": "StarlyToken",
+                        "fq_address": "A.0xf63219072aaddd50.StarlyToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138897941
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "address": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/starlycard-borrow-money-by-nft.json
+++ b/templates/Blocto/starlycard-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "be192425a3145713c4928cf1333708fb4258ee02d1fe6835f08739cdfc5fef50",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "StarlyCard Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/starlyCardCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890413
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890447
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890509
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890537
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/starlycard-cancel-borrow-money.json
+++ b/templates/Blocto/starlycard-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "c8a095052a97b9f86836d6f28dba1385ead05c36a4316307027b6c42ce1b98c0",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "StarlyCard Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/starlyCardCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890435
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890529
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/starlycard-force-redeem.json
+++ b/templates/Blocto/starlycard-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ffd1b78f95fedbea762c994a0fa9c5929178ab324b51fa5eed0b28419afa97db",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "StarlyCard Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/starlyCardCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890465
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890531
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/starlycard-lend-money.json
+++ b/templates/Blocto/starlycard-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "677fb853f3f2a4bcf791c241178707e54fe94e6a28bbfe511f86108818768e78",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "StarlyCard Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890526
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890539
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/starlycard-repay.json
+++ b/templates/Blocto/starlycard-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "d81119d8a988caaeb50a91f7013334e8fa084eeb027224e56754a1ca5e193af7",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "StarlyCard Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/starlyCardCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890529
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890580
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890637
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-beam-item.json
+++ b/templates/Blocto/storefront-buy-beam-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "6d94d64e9682d52d97e8fc874b940e4588d9b0f07d8a1f0f50d2a85bccc603ff",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy beam item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Fright Club NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport Beam from 0xBEAM_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &Beam.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&Beam.Collection>(from: Beam.CollectionStoragePath) == nil {\n            signer.save(<-Beam.createEmptyCollection(), to: Beam.CollectionStoragePath)\n            signer.link<&{Beam.BeamCollectionPublic}>(Beam.CollectionPublicPath, target: Beam.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&Beam.Collection{NonFungibleToken.Receiver}>(from: Beam.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898006
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898045
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898097
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898126
+                    }
+                }
+            },
+            "0xBEAM_ADDRESS": {
+                "Beam": {
+                    "testnet": {
+                        "address": "0x6085ae87e78e1433",
+                        "contract": "Beam",
+                        "fq_address": "A.0x6085ae87e78e1433.Beam",
+                        "pin": "d00a96b60721e1606bb257a08b3c1d3fa16be292ed87d3e51941c875f673da0f",
+                        "pin_block_height": 138898257
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-blocklete-games-item.json
+++ b/templates/Blocto/storefront-buy-blocklete-games-item.json
@@ -1,0 +1,88 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "c21641067d75c2f2269f88118911a5e7e747a2099baeb158b5b1d72fc89bf66f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy blocklete games item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Blocklete Games NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport BlockleteGames_NFT from 0xBLOCKLETE_GAMES_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &BlockleteGames_NFT.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&BlockleteGames_NFT.Collection>(from: BlockleteGames_NFT.CollectionStoragePath) == nil {\n            signer.save(<-BlockleteGames_NFT.createEmptyCollection(), to: BlockleteGames_NFT.CollectionStoragePath)\n            signer.link<&BlockleteGames_NFT.Collection{NonFungibleToken.CollectionPublic,BlockleteGames_NFT.BlockleteGames_NFTCollectionPublic}>(BlockleteGames_NFT.CollectionPublicPath, target: BlockleteGames_NFT.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&BlockleteGames_NFT.Collection{NonFungibleToken.Receiver}>(from: BlockleteGames_NFT.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898006
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898045
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898083
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898126
+                    }
+                }
+            },
+            "0xBLOCKLETE_GAMES_ADDRESS": {
+                "BlockleteGames_NFT": {}
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-caa-pass-item.json
+++ b/templates/Blocto/storefront-buy-caa-pass-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "a6a3ff18bd2800e3158d61622fba73c23d6b9496cc173ea268530647250f1a8f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy caa pass item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase THiNG.FUND NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport CaaPass from 0xCAA_PASS_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &CaaPass.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&CaaPass.Collection>(from: CaaPass.CollectionStoragePath) == nil {\n            signer.save(<-CaaPass.createEmptyCollection(), to: CaaPass.CollectionStoragePath)\n            signer.link<&{NonFungibleToken.CollectionPublic, CaaPass.CollectionPublic}>(CaaPass.CollectionPublicPath, target: CaaPass.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&CaaPass.Collection{NonFungibleToken.Receiver}>(from: CaaPass.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898007
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898056
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898128
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898148
+                    }
+                }
+            },
+            "0xCAA_PASS_ADDRESS": {
+                "CaaPass": {
+                    "testnet": {
+                        "address": "0xa8b1239250f8d342",
+                        "contract": "CaaPass",
+                        "fq_address": "A.0xa8b1239250f8d342.CaaPass",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138898245
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-chainmonsters-rewards-item.json
+++ b/templates/Blocto/storefront-buy-chainmonsters-rewards-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "f9a7bba72abbed26ec7bdbb6fcc4aff4482c2d9e411ce81d18c000123a3c5119",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy chainmonsters rewards item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Chainmonsters Rewards NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport ChainmonstersRewards from 0xCHAINMONSTERS_REWARDS_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &ChainmonstersRewards.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&ChainmonstersRewards.Collection>(from: /storage/ChainmonstersRewardCollection) == nil {\n            signer.save(<-ChainmonstersRewards.createEmptyCollection(), to: /storage/ChainmonstersRewardCollection)\n            signer.link<&{ChainmonstersRewards.ChainmonstersRewardCollectionPublic}>(/public/ChainmonstersRewardCollection, target: /storage/ChainmonstersRewardCollection)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&ChainmonstersRewards.Collection{NonFungibleToken.Receiver}>(from: /storage/ChainmonstersRewardCollection)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898130
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898171
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898225
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898259
+                    }
+                }
+            },
+            "0xCHAINMONSTERS_REWARDS_ADDRESS": {
+                "ChainmonstersRewards": {
+                    "testnet": {
+                        "address": "0x75783e3c937304a8",
+                        "contract": "ChainmonstersRewards",
+                        "fq_address": "A.0x75783e3c937304a8.ChainmonstersRewards",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138898370
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-collectible-item.json
+++ b/templates/Blocto/storefront-buy-collectible-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "aafb11b2f436c7ee6f3be76901bd60c70b688cb0ba91d463ca526bf06221d700",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy collectible item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase xtingles NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport Collectible from 0xXTINGLES_COLLECTIBLE_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &Collectible.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&Collectible.Collection>(from: Collectible.CollectionStoragePath) == nil {\n            signer.save(<-Collectible.createEmptyCollection(), to: Collectible.CollectionStoragePath)\n            signer.link<&{Collectible.CollectionPublic}>(Collectible.CollectionPublicPath, target: Collectible.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&Collectible.Collection{NonFungibleToken.Receiver}>(from: Collectible.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898148
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898186
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898257
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898287
+                    }
+                }
+            },
+            "0xXTINGLES_COLLECTIBLE_ADDRESS": {
+                "Collectible": {
+                    "testnet": {
+                        "address": "0x85080f371da20cc1",
+                        "contract": "Collectible",
+                        "fq_address": "A.0x85080f371da20cc1.Collectible",
+                        "pin": "ec7be5050256b8b9ab2a6f5550a42b6a64627fa7e684a88de5dd767864f0471a",
+                        "pin_block_height": 138898370
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-cricket-moments-item.json
+++ b/templates/Blocto/storefront-buy-cricket-moments-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "2a1dfd32d12901c53f71c91a48056cdc059856585cb15aad370fbb26c4977af8",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy cricket moments item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Faze NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport CricketMoments from 0xCRICKET_MOMENTS_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &CricketMoments.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&CricketMoments.Collection>(from: CricketMoments.CollectionStoragePath) == nil {\n            signer.save(<-CricketMoments.createEmptyCollection(), to: CricketMoments.CollectionStoragePath)\n            signer.link<&CricketMoments.Collection{NonFungibleToken.CollectionPublic, CricketMoments.CricketMomentsCollectionPublic}>(CricketMoments.CollectionPublicPath, target: CricketMoments.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&CricketMoments.Collection{NonFungibleToken.Receiver}>(from: CricketMoments.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898257
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898286
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898350
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898374
+                    }
+                }
+            },
+            "0xCRICKET_MOMENTS_ADDRESS": {
+                "CricketMoments": {
+                    "testnet": {
+                        "address": "0xb45e7992680a0f7f",
+                        "contract": "CricketMoments",
+                        "fq_address": "A.0xb45e7992680a0f7f.CricketMoments",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898410
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-everbloom-item.json
+++ b/templates/Blocto/storefront-buy-everbloom-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "042c66bed0a2ee4c968c59e483dd2ddde8df90807b49af5f178b56263d575ce7",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy everbloom item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Everbloom NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport Everbloom from 0xEVERBLOOM_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &Everbloom.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&Everbloom.Collection>(from: Everbloom.CollectionStoragePath) == nil {\n            signer.save(<-Everbloom.createEmptyCollection(), to: Everbloom.CollectionStoragePath)\n            signer.link<&{Everbloom.PrintCollectionPublic}>(Everbloom.CollectionPublicPath, target: Everbloom.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&Everbloom.Collection{NonFungibleToken.Receiver}>(from: Everbloom.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898270
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898315
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898370
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898374
+                    }
+                }
+            },
+            "0xEVERBLOOM_ADDRESS": {
+                "Everbloom": {
+                    "testnet": {
+                        "address": "0xf30d2f642de8c895",
+                        "contract": "Everbloom",
+                        "fq_address": "A.0xf30d2f642de8c895.Everbloom",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898438
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-fantastec-item.json
+++ b/templates/Blocto/storefront-buy-fantastec-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "cec826368966be4d7afde1a15a1a1075333ee1b5e046458dfd54c77b2f65941f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy fantastec item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Fantastec SWAP NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport FantastecNFT from 0xFANTASTEC_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &FantastecNFT.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&FantastecNFT.Collection>(from: FantastecNFT.CollectionStoragePath) == nil {\n            signer.save(<-FantastecNFT.createEmptyCollection(), to: FantastecNFT.CollectionStoragePath)\n            signer.link<&FantastecNFT.Collection{NonFungibleToken.CollectionPublic, FantastecNFT.FantastecNFTCollectionPublic}>(FantastecNFT.CollectionPublicPath, target: FantastecNFT.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&FantastecNFT.Collection{NonFungibleToken.Receiver}>(from: FantastecNFT.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898374
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898387
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898458
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898497
+                    }
+                }
+            },
+            "0xFANTASTEC_ADDRESS": {
+                "FantastecNFT": {
+                    "testnet": {
+                        "address": "0x7b4fab78fbddc57e",
+                        "contract": "FantastecNFT",
+                        "fq_address": "A.0x7b4fab78fbddc57e.FantastecNFT",
+                        "pin": "3c7796c792dc130c2e565c8246de8a8d5add43e7f340efe20c52568c43602b36",
+                        "pin_block_height": 138898667
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-gaia-item.json
+++ b/templates/Blocto/storefront-buy-gaia-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "8d8070e0b7e0c1312c0d85fdfacb677d8fa9718952bdb31c0462d1157d501020",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy gaia item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase BALLERZ NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport Gaia from 0xGAIA_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &Gaia.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&Gaia.Collection>(from: Gaia.CollectionStoragePath) == nil {\n            signer.save(<-Gaia.createEmptyCollection(), to: Gaia.CollectionStoragePath)\n            signer.link<&{Gaia.CollectionPublic}>(Gaia.CollectionPublicPath, target: Gaia.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&Gaia.Collection{NonFungibleToken.Receiver}>(from: Gaia.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898374
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898420
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898479
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898498
+                    }
+                }
+            },
+            "0xGAIA_ADDRESS": {
+                "Gaia": {
+                    "testnet": {
+                        "address": "0xc523a8bbf10fc4a3",
+                        "contract": "Gaia",
+                        "fq_address": "A.0xc523a8bbf10fc4a3.Gaia",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898551
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-klktn-item.json
+++ b/templates/Blocto/storefront-buy-klktn-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "d3d32bf6614ed506398e36bf016b739ccd0279d35d140adf5ace159edb65ccf6",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy klktn item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase KLKTN NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport KlktnNFT from 0xKLKTN_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &KlktnNFT.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&KlktnNFT.Collection>(from: KlktnNFT.CollectionStoragePath) == nil {\n            signer.save(<-KlktnNFT.createEmptyCollection(), to: KlktnNFT.CollectionStoragePath)\n            signer.link<&KlktnNFT.Collection{NonFungibleToken.CollectionPublic, KlktnNFT.KlktnNFTCollectionPublic}>(KlktnNFT.CollectionPublicPath, target: KlktnNFT.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&KlktnNFT.Collection{NonFungibleToken.Receiver}>(from: KlktnNFT.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898374
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898420
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898479
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898497
+                    }
+                }
+            },
+            "0xKLKTN_ADDRESS": {
+                "KlktnNFT": {
+                    "testnet": {
+                        "address": "0x336895dbe44c4b44",
+                        "contract": "KlktnNFT",
+                        "fq_address": "A.0x336895dbe44c4b44.KlktnNFT",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898551
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-kotd-item.json
+++ b/templates/Blocto/storefront-buy-kotd-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "32f066f3e7f0caa830390b31f89f43db847b06776aefaa50bea744fd64a720fb",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy kotd item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase King of The Dot NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport KOTD from 0xKOTD_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &KOTD.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&KOTD.Collection>(from: KOTD.CollectionStoragePath) == nil {\n            signer.save(<-KOTD.createEmptyCollection(), to: KOTD.CollectionStoragePath)\n            signer.link<&{KOTD.NiftoryCollectibleCollectionPublic}>(KOTD.CollectionPublicPath, target: KOTD.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&KOTD.Collection{NonFungibleToken.Receiver}>(from: KOTD.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898433
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898458
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898507
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898551
+                    }
+                }
+            },
+            "0xKOTD_ADDRESS": {
+                "KOTD": {
+                    "testnet": {
+                        "address": "0x6085ae87e78e1433",
+                        "contract": "KOTD",
+                        "fq_address": "A.0x6085ae87e78e1433.KOTD",
+                        "pin": "d00a96b60721e1606bb257a08b3c1d3fa16be292ed87d3e51941c875f673da0f",
+                        "pin_block_height": 138898667
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-matrix-world-flow-fest-item.json
+++ b/templates/Blocto/storefront-buy-matrix-world-flow-fest-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "190cb7b5b38da65023862dea859555ffb53b1fd639c23bd82aebe051018a8c86",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy matrix world flow fest item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase White Matrix NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport MatrixWorldFlowFestNFT from 0xMATRIX_WORLD_FLOWFEST_NFT_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &MatrixWorldFlowFestNFT.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&MatrixWorldFlowFestNFT.Collection>(from: MatrixWorldFlowFestNFT.CollectionStoragePath) == nil {\n            signer.save(<-MatrixWorldFlowFestNFT.createEmptyCollection(), to: MatrixWorldFlowFestNFT.CollectionStoragePath)\n            signer.link<&MatrixWorldFlowFestNFT.Collection{NonFungibleToken.CollectionPublic, MatrixWorldFlowFestNFT.MatrixWorldFlowFestNFTCollectionPublic}>(MatrixWorldFlowFestNFT.CollectionPublicPath, target: MatrixWorldFlowFestNFT.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&MatrixWorldFlowFestNFT.Collection{NonFungibleToken.Receiver}>(from: MatrixWorldFlowFestNFT.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898479
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898496
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898551
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898567
+                    }
+                }
+            },
+            "0xMATRIX_WORLD_FLOWFEST_NFT_ADDRESS": {
+                "MatrixWorldFlowFestNFT": {
+                    "testnet": {
+                        "address": "0xe2f1b000e0203c1d",
+                        "contract": "MatrixWorldFlowFestNFT",
+                        "fq_address": "A.0xe2f1b000e0203c1d.MatrixWorldFlowFestNFT",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898618
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-music-block-item.json
+++ b/templates/Blocto/storefront-buy-music-block-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "d90ba5e195a1485d32759fa18734d67b76bffd044b7c4972eb27cc5c8decd91a",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy music block item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Melos Studio NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport MusicBlock from 0xMUSIC_BLOCK_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &MusicBlock.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&MusicBlock.Collection>(from: MusicBlock.CollectionStoragePath) == nil {\n            signer.save(<-MusicBlock.createEmptyCollection(), to: MusicBlock.CollectionStoragePath)\n            signer.link<&MusicBlock.Collection{NonFungibleToken.CollectionPublic, MusicBlock.MusicBlockCollectionPublic}>(MusicBlock.CollectionPublicPath, target: MusicBlock.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&MusicBlock.Collection{NonFungibleToken.Receiver}>(from: MusicBlock.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898553
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898582
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898645
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898679
+                    }
+                }
+            },
+            "0xMUSIC_BLOCK_ADDRESS": {
+                "MusicBlock": {
+                    "testnet": {
+                        "address": "0xeb3241ad7d7881db",
+                        "contract": "MusicBlock",
+                        "fq_address": "A.0xeb3241ad7d7881db.MusicBlock",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898716
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-mynft-item.json
+++ b/templates/Blocto/storefront-buy-mynft-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "2bb3ee803a2e673dc0254b1b1b49aa3475d1285dfff51e606252b8efaa38b401",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy mynft item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Mynft (Racing Time, Mugen ARt, Voxel Knight) NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport Mynft from 0xMYNFT_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &Mynft.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&Mynft.Collection>(from: Mynft.CollectionStoragePath) == nil {\n            signer.save(<-Mynft.createEmptyCollection(), to: Mynft.CollectionStoragePath)\n            signer.link<&Mynft.Collection{NonFungibleToken.CollectionPublic, Mynft.MynftCollectionPublic}>(Mynft.CollectionPublicPath, target: Mynft.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&Mynft.Collection{NonFungibleToken.Receiver}>(from: Mynft.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898564
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898605
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898645
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898679
+                    }
+                }
+            },
+            "0xMYNFT_ADDRESS": {
+                "Mynft": {
+                    "testnet": {
+                        "address": "0x1eced429f2012ef0",
+                        "contract": "Mynft",
+                        "fq_address": "A.0x1eced429f2012ef0.Mynft",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898736
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-nyathees-ovo-item.json
+++ b/templates/Blocto/storefront-buy-nyathees-ovo-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "690bf6221aa78e8217f4b2bef0af5e09926bcbebcbb1e3355aec9e54fbc98edd",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy nyathees ovo item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase OVO NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport NyatheesOVO from 0xNYATHEES_OVO_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &NyatheesOVO.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&NyatheesOVO.Collection>(from: NyatheesOVO.CollectionStoragePath) == nil {\n            signer.save(<-NyatheesOVO.createEmptyCollection(), to: NyatheesOVO.CollectionStoragePath)\n            signer.link<&NyatheesOVO.Collection{NonFungibleToken.CollectionPublic, NyatheesOVO.NFTCollectionPublic}>(NyatheesOVO.CollectionPublicPath, target: NyatheesOVO.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&NyatheesOVO.Collection{NonFungibleToken.Receiver}>(from: NyatheesOVO.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898645
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898678
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898736
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898773
+                    }
+                }
+            },
+            "0xNYATHEES_OVO_ADDRESS": {
+                "NyatheesOVO": {
+                    "testnet": {
+                        "address": "0xacf3dfa413e00f9f",
+                        "contract": "NyatheesOVO",
+                        "fq_address": "A.0xacf3dfa413e00f9f.NyatheesOVO",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898805
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-race-day-item.json
+++ b/templates/Blocto/storefront-buy-race-day-item.json
@@ -1,0 +1,88 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "b41ab951b3556cd325944c64c012cb5fbd362e63145a3d5c8a3a9bceb1525f48",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy race day item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase RaceDay NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport RaceDay_NFT from 0xRACEDAY_NFT_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &RaceDay_NFT.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&RaceDay_NFT.Collection>(from: RaceDay_NFT.CollectionStoragePath) == nil {\n            signer.save(<-RaceDay_NFT.createEmptyCollection(), to: RaceDay_NFT.CollectionStoragePath)\n            signer.link<&RaceDay_NFT.Collection{NonFungibleToken.CollectionPublic, RaceDay_NFT.RaceDay_NFTCollectionPublic}>(RaceDay_NFT.CollectionPublicPath, target: RaceDay_NFT.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&RaceDay_NFT.Collection{NonFungibleToken.Receiver}>(from: RaceDay_NFT.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898681
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898716
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898764
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898791
+                    }
+                }
+            },
+            "0xRACEDAY_NFT_ADDRESS": {
+                "RaceDay_NFT": {}
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-rare-rooms-item.json
+++ b/templates/Blocto/storefront-buy-rare-rooms-item.json
@@ -1,0 +1,88 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "b9d372b186f77fc53d5a719b58bf892d89f96a4f52ee874934febde4ba5fc04f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy rare rooms item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase RareRooms NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport RareRooms_NFT from 0xRAREROOMS_NFT_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &RareRooms_NFT.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&RareRooms_NFT.Collection>(from: RareRooms_NFT.CollectionStoragePath) == nil {\n            signer.save(<-RareRooms_NFT.createEmptyCollection(), to: RareRooms_NFT.CollectionStoragePath)\n            signer.link<&RareRooms_NFT.Collection{NonFungibleToken.CollectionPublic, RareRooms_NFT.RareRooms_NFTCollectionPublic}>(RareRooms_NFT.CollectionPublicPath, target: RareRooms_NFT.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&RareRooms_NFT.Collection{NonFungibleToken.Receiver}>(from: RareRooms_NFT.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898742
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898784
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898824
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898858
+                    }
+                }
+            },
+            "0xRAREROOMS_NFT_ADDRESS": {
+                "RareRooms_NFT": {}
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-rcrdshp-item.json
+++ b/templates/Blocto/storefront-buy-rcrdshp-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "cbf814e676539f0118960a4e5d7f5cfb349fca5001643a6f296819fb471c3050",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy rcrdshp item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase RCRDSHP NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport RCRDSHPNFT from 0xRCRDSHP_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &RCRDSHPNFT.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&RCRDSHPNFT.Collection>(from: RCRDSHPNFT.collectionStoragePath) == nil {\n            signer.save(<-RCRDSHPNFT.createEmptyCollection(), to: RCRDSHPNFT.collectionStoragePath)\n            signer.link<&{NonFungibleToken.CollectionPublic}>(RCRDSHPNFT.collectionPublicPath, target: RCRDSHPNFT.collectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&RCRDSHPNFT.Collection{NonFungibleToken.Receiver}>(from: RCRDSHPNFT.collectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898679
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898716
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898764
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898791
+                    }
+                }
+            },
+            "0xRCRDSHP_ADDRESS": {
+                "RCRDSHPNFT": {
+                    "testnet": {
+                        "address": "0x95d41a94b49a1ed1",
+                        "contract": "RCRDSHPNFT",
+                        "fq_address": "A.0x95d41a94b49a1ed1.RCRDSHPNFT",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898838
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-shard-item.json
+++ b/templates/Blocto/storefront-buy-shard-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "1fde23ca720edeb75219db025c2d9ee149ea01fc1df5e1633d3a6f85d1f5c83f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy shard item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Eternal Shard NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport Shard from 0xETERNAL_SHARD_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &Shard.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&Shard.Collection>(from: /storage/EternalShardCollection) == nil {\n            signer.save(<-Shard.createEmptyCollection(), to: /storage/EternalShardCollection)\n            signer.link<&{Shard.ShardCollectionPublic}>(/public/EternalShardCollection, target: /storage/EternalShardCollection)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&Shard.Collection{NonFungibleToken.Receiver}>(from: /storage/EternalShardCollection)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898742
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898784
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898824
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898858
+                    }
+                }
+            },
+            "0xETERNAL_SHARD_ADDRESS": {
+                "Shard": {
+                    "testnet": {
+                        "address": "0x7ff5f9ac593c3ee0",
+                        "contract": "Shard",
+                        "fq_address": "A.0x7ff5f9ac593c3ee0.Shard",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898919
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-sports-icon-item.json
+++ b/templates/Blocto/storefront-buy-sports-icon-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "a65a80b22a88ae5f715b7ffae944c3385f3911aaac6d83f5f28e8e81659b4446",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy sports icon item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase SportsIcon NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport SportsIconCollectible from 0xSPORTS_ICON_COLLECTIBLE_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &SportsIconCollectible.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&SportsIconCollectible.Collection>(from: SportsIconCollectible.CollectionStoragePath) == nil {\n            signer.save(<-SportsIconCollectible.createEmptyCollection(), to: SportsIconCollectible.CollectionStoragePath)\n            signer.link<&SportsIconCollectible.Collection{NonFungibleToken.CollectionPublic, NonFungibleToken.Receiver, SportsIconCollectible.CollectibleCollectionPublic}>(SportsIconCollectible.CollectionPublicPath, target: SportsIconCollectible.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&SportsIconCollectible.Collection{NonFungibleToken.Receiver}>(from: SportsIconCollectible.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898826
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898858
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898919
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898938
+                    }
+                }
+            },
+            "0xSPORTS_ICON_COLLECTIBLE_ADDRESS": {
+                "SportsIconCollectible": {
+                    "testnet": {
+                        "address": "0xc2824327396d3a39",
+                        "contract": "SportsIconCollectible",
+                        "fq_address": "A.0xc2824327396d3a39.SportsIconCollectible",
+                        "pin": "751fcffa1f40d4edff5f6cff49d14e6b67bbd33cad3d2dd61fdc04ce97db4a4a",
+                        "pin_block_height": 138899049
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-starly-card-item.json
+++ b/templates/Blocto/storefront-buy-starly-card-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "601aeaf5a38b1695ffade2408a41b10a20269de76ad9c247becfc8a96afa0f5e",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy starly card item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Starly NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport StarlyCard from 0xSTARLY_CARD_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &StarlyCard.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&StarlyCard.Collection>(from: StarlyCard.CollectionStoragePath) == nil {\n            signer.save(<-StarlyCard.createEmptyCollection(), to: StarlyCard.CollectionStoragePath)\n            signer.link<&StarlyCard.Collection{NonFungibleToken.CollectionPublic,StarlyCard.StarlyCardCollectionPublic}>(StarlyCard.CollectionPublicPath,target: StarlyCard.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&StarlyCard.Collection{NonFungibleToken.Receiver}>(from: StarlyCard.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898860
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898919
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898959
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898989
+                    }
+                }
+            },
+            "0xSTARLY_CARD_ADDRESS": {
+                "StarlyCard": {
+                    "testnet": {
+                        "address": "0x697d72a988a77070",
+                        "contract": "StarlyCard",
+                        "fq_address": "A.0x697d72a988a77070.StarlyCard",
+                        "pin": "455a9a9d9530fe73aeba8c3f857fce0ad33438592943e4b391a6b92418cce5e8",
+                        "pin_block_height": 138899194
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-the-fabricant-mystery-box-item.json
+++ b/templates/Blocto/storefront-buy-the-fabricant-mystery-box-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "359917d0a1df819775a3f65f4e914cf2baa4925853acad4124109b98b5d68be3",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy the fabricant mystery box item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase The Fabricant NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport TheFabricantMysteryBox_FF1 from 0xTHEFABRICANT_MYSTERYBOX_FF1_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &TheFabricantMysteryBox_FF1.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&TheFabricantMysteryBox_FF1.Collection>(from: TheFabricantMysteryBox_FF1.CollectionStoragePath) == nil {\n            signer.save(<-TheFabricantMysteryBox_FF1.createEmptyCollection(), to: TheFabricantMysteryBox_FF1.CollectionStoragePath)\n            signer.link<&{TheFabricantMysteryBox_FF1.FabricantCollectionPublic}>(TheFabricantMysteryBox_FF1.CollectionPublicPath, target: TheFabricantMysteryBox_FF1.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&TheFabricantMysteryBox_FF1.Collection{NonFungibleToken.Receiver}>(from: TheFabricantMysteryBox_FF1.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898826
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898858
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898919
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898938
+                    }
+                }
+            },
+            "0xTHEFABRICANT_MYSTERYBOX_FF1_ADDRESS": {
+                "TheFabricantMysteryBox_FF1": {
+                    "testnet": {
+                        "address": "0xbc9d692e2617a96e",
+                        "contract": "TheFabricantMysteryBox_FF1",
+                        "fq_address": "A.0xbc9d692e2617a96e.TheFabricantMysteryBox_FF1",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138899006
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-top-shot-item.json
+++ b/templates/Blocto/storefront-buy-top-shot-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "626ffe8e7fb3ca3208e2c92186a3e495283ce71687eb09b9963808e14f279307",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy top shot item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase TopShot NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport TopShot from 0xTOPSHOT_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &TopShot.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&TopShot.Collection>(from: /storage/MomentCollection) == nil {\n            signer.save(<-TopShot.createEmptyCollection(), to: /storage/MomentCollection)\n            signer.link<&{TopShot.MomentCollectionPublic}>(/public/MomentCollection, target: /storage/MomentCollection)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&TopShot.Collection{NonFungibleToken.Receiver}>(from: /storage/MomentCollection)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898868
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898928
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138898959
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138898999
+                    }
+                }
+            },
+            "0xTOPSHOT_ADDRESS": {
+                "TopShot": {
+                    "testnet": {
+                        "address": "0x877931736ee77cff",
+                        "contract": "TopShot",
+                        "fq_address": "A.0x877931736ee77cff.TopShot",
+                        "pin": "d00a96b60721e1606bb257a08b3c1d3fa16be292ed87d3e51941c875f673da0f",
+                        "pin_block_height": 138899120
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-tune-go-item.json
+++ b/templates/Blocto/storefront-buy-tune-go-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "6f2c02c974b94374c324846505b6adbe3d0f7619639d77f9505134b7d3e89ecb",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy tune go item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Tune Go NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport TuneGO from 0xTUNE_GO_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &TuneGO.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&TuneGO.Collection>(from: TuneGO.CollectionStoragePath) == nil {\n            signer.save(<-TuneGO.createEmptyCollection(), to: TuneGO.CollectionStoragePath)\n            signer.link<&{TuneGO.TuneGOCollectionPublic}>(TuneGO.CollectionPublicPath, target: TuneGO.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&TuneGO.Collection{NonFungibleToken.Receiver}>(from: TuneGO.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898938
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138898971
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138899027
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138899056
+                    }
+                }
+            },
+            "0xTUNE_GO_ADDRESS": {
+                "TuneGO": {
+                    "testnet": {
+                        "address": "0x2b0150231c047a8c",
+                        "contract": "TuneGO",
+                        "fq_address": "A.0x2b0150231c047a8c.TuneGO",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138899106
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-buy-vouchers-item.json
+++ b/templates/Blocto/storefront-buy-vouchers-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "8cda69bb101081d5fc669775665b0ef6f45c2721a239634e2b5d078ba7f0730b",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Buy vouchers item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Purchase Jambb Voucher NFT for {buyPrice} FLOW from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\nimport Vouchers from 0xJAMBB_VOUCHERS_ADDRESS\n\ntransaction(listingResourceID: UInt64, storefrontAddress: Address, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let nftCollection: &Vouchers.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&Vouchers.Collection>(from: Vouchers.CollectionStoragePath) == nil {\n            signer.save(<-Vouchers.createEmptyCollection(), to: Vouchers.CollectionStoragePath)\n            signer.link<&{Vouchers.CollectionPublic}>(Vouchers.CollectionPublicPath, target: Vouchers.CollectionStoragePath)\n        }\n\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n            ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let flowTokenVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Cannot borrow FlowToken vault from signer storage\")\n        self.paymentVault <- flowTokenVault.withdraw(amount: price)\n\n        self.nftCollection = signer.borrow<&Vouchers.Collection{NonFungibleToken.Receiver}>(from: Vouchers.CollectionStoragePath)\n            ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(payment: <-self.paymentVault)\n        self.nftCollection.deposit(token: <-item)\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138899049
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138899077
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138899144
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138899177
+                    }
+                }
+            },
+            "0xJAMBB_VOUCHERS_ADDRESS": {
+                "Vouchers": {
+                    "testnet": {
+                        "address": "0xe94a6e229293f196",
+                        "contract": "Vouchers",
+                        "fq_address": "A.0xe94a6e229293f196.Vouchers",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138899237
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "storefrontAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/storefront-remove-item.json
+++ b/templates/Blocto/storefront-remove-item.json
@@ -1,0 +1,42 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "d4df1d7649eac368780ab96677ca4a684422a73dc6010147f391bc2482f23c39",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "storefront Remove item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Remove NFT listing from sale"
+                }
+            }
+        },
+        "cadence": "import NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\n\ntransaction(listingResourceID: UInt64) {\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontManager}\n\n    prepare(signer: AuthAccount) {\n        self.storefront = signer.borrow<&NFTStorefront.Storefront{NFTStorefront.StorefrontManager}>(from: NFTStorefront.StorefrontStoragePath)\n            ?? panic(\"Missing or mis-typed NFTStorefront.Storefront\")\n    }\n\n    execute {\n        self.storefront.removeListing(listingResourceID: listingResourceID)\n    }\n}\n",
+        "dependencies": {
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138899106
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/teleportedtethertoken-send-teleported-tether-token.json
+++ b/templates/Blocto/teleportedtethertoken-send-teleported-tether-token.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "5114a790cce1cc928f151b4d6fb9c3186b37dbe46491afdab9333bb19c607233",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TeleportedTetherToken Send teleported tether token"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Send {amount} tUSDT to {to}",
+                    "zh-CN": "发送 {amount} tUSDT 代币至 {to}",
+                    "zh-TW": "發送 {amount} tUSDT 代幣至 {to}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport TeleportedTetherToken from 0xTELEPORTED_USDT_ADDRESS\n\ntransaction(amount: UFix64, to: Address) {\n\n    // The Vault resource that holds the tokens that are being transferred\n    let sentVault: @FungibleToken.Vault\n\n    prepare(signer: AuthAccount) {\n\n        // Get a reference to the signer's stored vault\n        let vaultRef = signer.borrow<&TeleportedTetherToken.Vault>(from: TeleportedTetherToken.TokenStoragePath)\n            ?? panic(\"Could not borrow reference to the owner's Vault!\")\n\n        // Withdraw tokens from the signer's stored vault\n        self.sentVault <- vaultRef.withdraw(amount: amount)\n    }\n\n    execute {\n\n        // Get the recipient's public account object\n        let recipient = getAccount(to)\n\n        // Get a reference to the recipient's Receiver\n        let receiverRef = recipient.getCapability(TeleportedTetherToken.TokenPublicReceiverPath)\n            .borrow<&{FungibleToken.Receiver}>()\n            ?? panic(\"Could not borrow receiver reference to the recipient's Vault\")\n\n        // Deposit the withdrawn tokens in the recipient's receiver\n        receiverRef.deposit(from: <-self.sentVault)\n    }\n}",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138840748
+                    }
+                }
+            },
+            "0xTELEPORTED_USDT_ADDRESS": {
+                "TeleportedTetherToken": {
+                    "testnet": {
+                        "address": "0xab26e0a07d770ec1",
+                        "contract": "TeleportedTetherToken",
+                        "fq_address": "A.0xab26e0a07d770ec1.TeleportedTetherToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138880742
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "amount": {
+                "index": 0,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "to": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/tfcitems-borrow-money-by-nft.json
+++ b/templates/Blocto/tfcitems-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "50b7067c8c58027fcc529e9c289fceba82977fde296b53a80ecb682f0967b21b",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TFCItems Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/TFCItemsCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890288
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890333
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890408
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890447
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/tfcitems-cancel-borrow-money.json
+++ b/templates/Blocto/tfcitems-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "1614468a3a1772178b64fe7cec687213d49cab165d8df3654152898d4217adf3",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TFCItems Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/TFCItemsCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890311
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890401
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/tfcitems-force-redeem.json
+++ b/templates/Blocto/tfcitems-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "1ff796e0a830218cf2bf449585f34660f8df1da0f5bd8a1c88ee40d404dfe4e3",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TFCItems Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/TFCItemsCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890311
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890406
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/tfcitems-lend-money.json
+++ b/templates/Blocto/tfcitems-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "549455f093fbf03a4ffc6f7850a39741f759c2f182aa6662909dcf463366cec0",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TFCItems Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890447
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890471
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/tfcitems-repay.json
+++ b/templates/Blocto/tfcitems-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "d923e8b03ef3c13683d82d91937ef75266155f9fe8a232059d5a5272033ef322",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TFCItems Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/TFCItemsCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890332
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890408
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890435
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/thefootballclub-buy-tfc-item.json
+++ b/templates/Blocto/thefootballclub-buy-tfc-item.json
@@ -1,0 +1,96 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "262fdf986634f2c28861043f946510adb124a656d81a662bebd085dd4565ad8b",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TheFootballClub Buy tfc item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Buy NFT with {buyPrice} FUSD from {storefrontAddress}"
+                }
+            }
+        },
+        "cadence": "import FUSD from 0xFUSD_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport TFCItems from 0xTFC_ITEMS_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\n\n/*\n    This transaction is used to buy a TFCItem for FUSD\n */\ntransaction(storefrontAddress: Address, listingResourceID: UInt64, buyPrice: UFix64) {\n    let paymentVault: @FungibleToken.Vault\n    let TFCItemsCollection: &TFCItems.Collection{NonFungibleToken.Receiver}\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}\n    let listing: &NFTStorefront.Listing{NFTStorefront.ListingPublic}\n\n    prepare(acct: AuthAccount) {\n        self.storefront = getAccount(storefrontAddress)\n            .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(\n                NFTStorefront.StorefrontPublicPath\n            )!\n            .borrow()\n            ?? panic(\"Could not borrow Storefront from provided address\")\n\n        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)\n                    ?? panic(\"No Offer with that ID in Storefront\")\n        let price = self.listing.getDetails().salePrice\n\n        assert(buyPrice == price, message: \"buyPrice is NOT same with salePrice\")\n\n        let mainFlowVault = acct.borrow<&FUSD.Vault>(from: /storage/fusdVault)\n            ?? panic(\"Cannot borrow FUSD vault from acct storage\")\n        self.paymentVault <- mainFlowVault.withdraw(amount: price)\n\n        self.TFCItemsCollection = acct.borrow<&TFCItems.Collection{NonFungibleToken.Receiver}>(\n            from: TFCItems.CollectionStoragePath\n        ) ?? panic(\"Cannot borrow NFT collection receiver from account\")\n    }\n\n    execute {\n        let item <- self.listing.purchase(\n            payment: <-self.paymentVault\n        )\n\n        self.TFCItemsCollection.deposit(token: <-item)\n        \n        // Be kind and recycle\n        self.storefront.cleanup(listingResourceID: listingResourceID)\n    }\n}",
+        "dependencies": {
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138881084
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138881101
+                    }
+                }
+            },
+            "0xTFC_ITEMS_ADDRESS": {
+                "TFCItems": {
+                    "testnet": {
+                        "address": "0x91a6217c3b70cae8",
+                        "contract": "TFCItems",
+                        "fq_address": "A.0x91a6217c3b70cae8.TFCItems",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138881196
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138881254
+                    }
+                }
+            },
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138881276
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "storefrontAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "listingResourceID": {
+                "index": 1,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "buyPrice": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/thefootballclub-initialize-account.json
+++ b/templates/Blocto/thefootballclub-initialize-account.json
@@ -1,0 +1,64 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "ea383bb0004febd853f21013afb412c22c243d34528e37e32c088596d3539e01",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TheFootballClub Initialize account"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Initialize your account to buy, sell and receive NFTs"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport TFCItems from 0xTFC_ITEMS_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\n\n/*\n    Check if an account has a TFCItems Collection capability\n */\npub fun hasItems(_ address: Address): Bool {\n    return getAccount(address)\n    .getCapability<&TFCItems.Collection{NonFungibleToken.CollectionPublic, TFCItems.TFCItemsCollectionPublic}>(TFCItems.CollectionPublicPath)\n    .check()\n}\n/*\n    Check if an account has a storefront capability\n */\npub fun hasStorefont(_ address: Address): Bool {\n    return getAccount(address)\n    .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath)\n    .check()\n}\n\n/*\n    This transaction configures an account to hold TFC Items & an NFTStorefont\n */\ntransaction {\n    prepare(signer: AuthAccount) {\n    \n\n    // if a TFCItems collection is not created yet we make it.\n    if !hasItems(signer.address) {\n        if signer.borrow<&TFCItems.Collection>(from: TFCItems.CollectionStoragePath) == nil {\n            signer.save(<-TFCItems.createEmptyCollection(), to: TFCItems.CollectionStoragePath)\n            signer.unlink(TFCItems.CollectionPublicPath)\n            signer.link<&TFCItems.Collection{NonFungibleToken.CollectionPublic, TFCItems.TFCItemsCollectionPublic}>(TFCItems.CollectionPublicPath, target: TFCItems.CollectionStoragePath)\n        }\n    }\n\n    // if a NFTStorefront is not created yet we make it.\n    if !hasStorefont(signer.address) {\n        if signer.borrow<&NFTStorefront.Storefront>(from: NFTStorefront.StorefrontStoragePath) == nil {\n            let storefront <- NFTStorefront.createStorefront() as! @NFTStorefront.Storefront        \n            signer.save(<-storefront, to: NFTStorefront.StorefrontStoragePath)\n            signer.link<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(NFTStorefront.StorefrontPublicPath, target: NFTStorefront.StorefrontStoragePath)\n        }\n    }\n\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138881127
+                    }
+                }
+            },
+            "0xTFC_ITEMS_ADDRESS": {
+                "TFCItems": {
+                    "testnet": {
+                        "address": "0x91a6217c3b70cae8",
+                        "contract": "TFCItems",
+                        "fq_address": "A.0x91a6217c3b70cae8.TFCItems",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138881216
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138881273
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "address": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/thefootballclub-remove-listing.json
+++ b/templates/Blocto/thefootballclub-remove-listing.json
@@ -1,0 +1,42 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "e60fbcea91ea5be10c96cefb338206c4ada5d00fb7b3b31767ce860dc06e1c0b",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TheFootballClub Remove listing"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Remove NFT item sale listing"
+                }
+            }
+        },
+        "cadence": "import NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\n\n/*\n    Removes a listing from an account's storefront\n*/\ntransaction(listingResourceID: UInt64) {\n    let storefront: &NFTStorefront.Storefront{NFTStorefront.StorefrontManager}\n\n    prepare(acct: AuthAccount) {\n        self.storefront = acct.borrow<&NFTStorefront.Storefront{NFTStorefront.StorefrontManager}>(from: NFTStorefront.StorefrontStoragePath)\n            ?? panic(\"Missing or mis-typed NFTStorefront.Storefront\")\n    }\n\n    execute {\n        self.storefront.removeListing(listingResourceID: listingResourceID)\n    }\n}",
+        "dependencies": {
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138881112
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "listingResourceID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/thefootballclub-sell-tfc-item.json
+++ b/templates/Blocto/thefootballclub-sell-tfc-item.json
@@ -1,0 +1,91 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "7a44f38bcb9f72e726db4de5d76ccc4e683fdb8332eb9757123ec975af5d87cb",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TheFootballClub Sell tfc item"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Place NFT item #{saleItemID} for sale for {saleItemPrice} FUSD"
+                }
+            }
+        },
+        "cadence": "import FUSD from 0xFUSD_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport TFCItems from 0xTFC_ITEMS_ADDRESS\nimport NFTStorefront from 0xNFT_STOREFRONT_ADDRESS\nimport FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\n\n/*\n    This transaction is used to sell a TFCItem for FUSD\n */\ntransaction(saleItemID: UInt64, saleItemPrice: UFix64) {\n    let fusdReceiver: Capability<&FUSD.Vault{FungibleToken.Receiver}>\n    let TFCItemsProvider: Capability<&TFCItems.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>\n    let storefront: &NFTStorefront.Storefront\n\n    prepare(acct: AuthAccount) {\n        // We need a provider capability, but one is not provided by default so we create one if needed.\n        let TFCItemsCollectionProviderPrivatePath = /private/TFCItemsCollectionProviderForNFTStorefront\n\n        self.fusdReceiver = acct.getCapability<&FUSD.Vault{FungibleToken.Receiver}>(/public/fusdReceiver)!\n        assert(self.fusdReceiver.borrow() != nil, message: \"Missing or mis-typed FUSD receiver\")\n\n        if !acct.getCapability<&TFCItems.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(TFCItemsCollectionProviderPrivatePath)!.check() {\n            acct.link<&TFCItems.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(TFCItemsCollectionProviderPrivatePath, target: TFCItems.CollectionStoragePath)\n        }\n        \n        self.TFCItemsProvider = acct.getCapability<&TFCItems.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(TFCItemsCollectionProviderPrivatePath)!\n        assert(self.TFCItemsProvider.borrow() != nil, message: \"Missing or mis-typed TFCItems.Collection provider\")\n\n        self.storefront = acct.borrow<&NFTStorefront.Storefront>(from: NFTStorefront.StorefrontStoragePath)\n            ?? panic(\"Missing or mis-typed NFTStorefront Storefront\")\n    }\n\n    execute {\n        let saleCut = NFTStorefront.SaleCut(\n            receiver: self.fusdReceiver,\n            amount: saleItemPrice\n        )\n        self.storefront.createListing(\n            nftProviderCapability: self.TFCItemsProvider,\n            nftType: Type<@TFCItems.NFT>(),\n            nftID: saleItemID,\n            salePaymentVaultType: Type<@FUSD.Vault>(),\n            saleCuts: [saleCut]\n        )\n    }\n}",
+        "dependencies": {
+            "0xFUSD_ADDRESS": {
+                "FUSD": {
+                    "testnet": {
+                        "address": "0xe223d8a629e49c68",
+                        "contract": "FUSD",
+                        "fq_address": "A.0xe223d8a629e49c68.FUSD",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138881145
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138881196
+                    }
+                }
+            },
+            "0xTFC_ITEMS_ADDRESS": {
+                "TFCItems": {
+                    "testnet": {
+                        "address": "0x91a6217c3b70cae8",
+                        "contract": "TFCItems",
+                        "fq_address": "A.0x91a6217c3b70cae8.TFCItems",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138881284
+                    }
+                }
+            },
+            "0xNFT_STOREFRONT_ADDRESS": {
+                "NFTStorefront": {
+                    "testnet": {
+                        "address": "0x94b06cfca1d8a476",
+                        "contract": "NFTStorefront",
+                        "fq_address": "A.0x94b06cfca1d8a476.NFTStorefront",
+                        "pin": "ba061d95016d5506e9f5d1afda15d82eb066aa8b0552e8b26dc7950fa5714d51",
+                        "pin_block_height": 138881323
+                    }
+                }
+            },
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138881356
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "saleItemID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "saleItemPrice": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/topshot-borrow-money-by-nft.json
+++ b/templates/Blocto/topshot-borrow-money-by-nft.json
@@ -1,0 +1,92 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "33311cb01c403a37c81b19682735d8973b0ba7d1ca851dd39bc36b733a73bbaa",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TopShot Borrow money by nft"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend NFT {id} in {baseAmount} FLOW tokens.",
+                    "zh-CN": "以 {baseAmount} FLOW 代币出借 NFT {id}",
+                    "zh-TW": "以 {baseAmount} FLOW 代幣出借 NFT {id}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// List an NFT in the account storage for lending\ntransaction(id: UInt64, baseAmount: UFix64, interest: UFix64, duration: UFix64) {\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&AnyResource{NFTLendingPlace.LendingPublic}>(from: /storage/NFTLendingPlaceCollection) == nil {\n            let receiver = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)\n            let lendingPlace <- NFTLendingPlace.createLendingCollection(ownerVault: receiver)\n            acct.save(<-lendingPlace, to: /storage/NFTLendingPlaceCollection)\n            acct.link<&NFTLendingPlace.LendingCollection{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection, target: /storage/NFTLendingPlaceCollection)\n        }\n\n        let lendingPlace = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MomentCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        // Withdraw the NFT to use as collateral\n        let token <- collectionRef.withdraw(withdrawID: id)\n\n        // List the NFT as collateral\n        lendingPlace.listForLending(owner: acct.address, token: <-token, baseAmount: baseAmount, interest: interest, duration: duration)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890164
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890192
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890262
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890288
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "id": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "baseAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "interest": {
+                "index": 2,
+                "type": "UFix64",
+                "messages": {}
+            },
+            "duration": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/topshot-cancel-borrow-money.json
+++ b/templates/Blocto/topshot-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "6129ce0fe0729277df3feede8f8be78f5979612846a71fd858c5c3d7111a68fa",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TopShot Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MomentCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890234
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890288
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/topshot-force-redeem.json
+++ b/templates/Blocto/topshot-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "f38ceef431de1f055090893593fe7915327c09867e864591cc888f76e34fe5cd",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TopShot Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MomentCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890180
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890260
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/topshot-lend-money.json
+++ b/templates/Blocto/topshot-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "905c8bc38563a0517376c75f3b95015d9f7dcbd1459e5c68ef5aba705c402d8e",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TopShot Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890244
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890276
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/topshot-repay.json
+++ b/templates/Blocto/topshot-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "510e2c9bdcd8b85bc93d26fec237b4d765219ec036e20768806a1af40b076143",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "TopShot Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/MomentCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890288
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890380
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890406
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/user-batch-comment.json
+++ b/templates/Blocto/user-batch-comment.json
@@ -1,0 +1,47 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "f08009f709e47b83519ceed58c869638ba116b98c142e8dfb3a53ac23aa9b89f",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "user Batch comment"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Create comment"
+                }
+            }
+        },
+        "cadence": "// batchCreateComment v2\nimport MIKOSEANFT from 0xMIKOSEA_MIKOSEANFT_ADDRESS\n\ntransaction(nftIDs:[UInt64], comment: String){\n    let address: Address\n    let projectId:UInt64\n    let itemId:UInt64\n\n    prepare(signer:AuthAccount){\n        self.address = signer.address\n        if let nftData = MIKOSEANFT.fetch(_from: self.address, itemId: nftIDs[0]) {\n            self.projectId = nftData.data.projectId\n            self.itemId = nftData.data.itemId\n        } else {\n            panic(\"Not found nft\")\n        }\n    }\n    execute{\n        for nftId in nftIDs {\n            MIKOSEANFT.createComment(projectId:self.projectId, itemId:self.itemId, userAddress:self.address, nftId:nftId, comment: comment)\n        }\n    }\n}\n",
+        "dependencies": {
+            "0xMIKOSEA_MIKOSEANFT_ADDRESS": {
+                "MIKOSEANFT": {
+                    "testnet": {
+                        "address": "0x713306ac51ac7ddb",
+                        "contract": "MIKOSEANFT",
+                        "fq_address": "A.0x713306ac51ac7ddb.MIKOSEANFT",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138900470
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "nftIDs": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "comment": {
+                "index": 1,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/user-batch-delete-comment.json
+++ b/templates/Blocto/user-batch-delete-comment.json
@@ -1,0 +1,42 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "76bfc0e7b312becf5b6a8927b5f8d6de870a08f63633a811bfdc2636483babd0",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "user Batch delete comment"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Delete comment"
+                }
+            }
+        },
+        "cadence": "import MIKOSEANFT from 0xMIKOSEA_MIKOSEANFT_ADDRESS\n\ntransaction(commentIds:[UInt64]){\n  execute{\n    for commentId in commentIds {\n      MIKOSEANFT.deleteComment(commentId: commentId)\n    }\n  }\n}\n",
+        "dependencies": {
+            "0xMIKOSEA_MIKOSEANFT_ADDRESS": {
+                "MIKOSEANFT": {
+                    "testnet": {
+                        "address": "0x713306ac51ac7ddb",
+                        "contract": "MIKOSEANFT",
+                        "fq_address": "A.0x713306ac51ac7ddb.MIKOSEANFT",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138900567
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "commentIds": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/user-edit-comment.json
+++ b/templates/Blocto/user-edit-comment.json
@@ -1,0 +1,47 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "c56b8bb10e1682b1a61a5d56f4a54cd50aa034042378e8abf1017a4269341a22",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "user Edit comment"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Edit comment"
+                }
+            }
+        },
+        "cadence": "// EditComment-v2\nimport MIKOSEANFT from 0xMIKOSEA_MIKOSEANFT_ADDRESS\n\ntransaction(commentId:UInt64, comment: String){\n    let address: Address\n    var commentDetail: MIKOSEANFT.Comment?\n\n    prepare(signer: AuthAccount) {\n        self.address = signer.address\n        self.commentDetail = nil\n        let comments = MIKOSEANFT.getAllComments()\n        for e in comments {\n            if e.commentId == commentId {\n                self.commentDetail = e\n                break\n            }\n        }\n        if self.commentDetail == nil {\n            panic(\"not found comment\")\n        }\n    }\n\n    execute{\n        MIKOSEANFT.editComment(commentId: commentId, projectId: self.commentDetail!.projectId, itemId: self.commentDetail!.itemId, userAddress: self.address, nftId: self.commentDetail!.nftId, newComment: comment)\n    }\n}",
+        "dependencies": {
+            "0xMIKOSEA_MIKOSEANFT_ADDRESS": {
+                "MIKOSEANFT": {
+                    "testnet": {
+                        "address": "0x713306ac51ac7ddb",
+                        "contract": "MIKOSEANFT",
+                        "fq_address": "A.0x713306ac51ac7ddb.MIKOSEANFT",
+                        "pin": "9524cc8b5eb8bb8f7d8cf4ee3c65374cafa55921d31d6f72ce08d1c4da8aad57",
+                        "pin_block_height": 138900528
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "commentId": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "comment": {
+                "index": 1,
+                "type": "String",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/vesting-release.json
+++ b/templates/Blocto/vesting-release.json
@@ -1,0 +1,64 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "474ed2bcf18bd7dfc03e839f09d5443c74932c9315390880e92a24fc2d8aee67",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "vesting Release"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Release available tokens from vesting #{vestingID}"
+                }
+            }
+        },
+        "cadence": "import FungibleToken from 0xFUNGIBLE_TOKEN_ADDRESS\nimport NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport StarlyTokenVesting from 0xSTARLY_TOKEN_VESTING_ADDRESS\n\ntransaction(vestingID: UInt64) {\n    let vestingCollectionRef: &StarlyTokenVesting.Collection\n\n    prepare(acct: AuthAccount) {\n        self.vestingCollectionRef = acct.borrow<&StarlyTokenVesting.Collection>(from: StarlyTokenVesting.CollectionStoragePath)\n            ?? panic(\"Could not borrow reference to the owner's StarlyTokenVesting collection!\")\n    }\n\n    execute {\n        self.vestingCollectionRef.release(id: vestingID)\n    }\n}\n",
+        "dependencies": {
+            "0xFUNGIBLE_TOKEN_ADDRESS": {
+                "FungibleToken": {
+                    "testnet": {
+                        "address": "0x9a0766d93b6608b7",
+                        "contract": "FungibleToken",
+                        "fq_address": "A.0x9a0766d93b6608b7.FungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138895214
+                    }
+                }
+            },
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138897942
+                    }
+                }
+            },
+            "0xSTARLY_TOKEN_VESTING_ADDRESS": {
+                "StarlyTokenVesting": {
+                    "testnet": {
+                        "address": "0xd2af9f588d53759d",
+                        "contract": "StarlyTokenVesting",
+                        "fq_address": "A.0xd2af9f588d53759d.StarlyTokenVesting",
+                        "pin": "d00a96b60721e1606bb257a08b3c1d3fa16be292ed87d3e51941c875f673da0f",
+                        "pin_block_height": 138898002
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "vestingID": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/vouchers-cancel-borrow-money.json
+++ b/templates/Blocto/vouchers-cancel-borrow-money.json
@@ -1,0 +1,55 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "253420497bfbf17009984dfcd581f1bd4250e319fc865d1920ee381b8d322df6",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Vouchers Cancel borrow money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Unlist {Uuid}.",
+                    "zh-CN": "下架 {Uuid}",
+                    "zh-TW": "下架 {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the NFT owner unlist NFT from NFTLendingPlace's resource\ntransaction(Uuid: UInt64) {\n\n    prepare(acct: AuthAccount) {\n\n        let lending = acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's vault resource\")\n\n        // Borrow a reference to the NFTCollection in storage\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/jambbLaunchVouchersCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection resource\")\n\n        let NFTtoken <- lending.withdraw(uuid: Uuid)\n\n        collectionRef.deposit(token: <- NFTtoken)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890670
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890764
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/vouchers-force-redeem.json
+++ b/templates/Blocto/vouchers-force-redeem.json
@@ -1,0 +1,60 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "e8f441216e540dc524b8f230a37661ade96a59dbefb07b0f9bf994652db10d3c",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Vouchers Force redeem"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Forced redeem of NFT {Uuid} on {BorrowerAddress} debit.",
+                    "zh-CN": "对 {BorrowerAddress} 借方强制清算 NFT {Uuid}",
+                    "zh-TW": "對 {BorrowerAddress} 借方強制清算 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\n\n// Let the lender get borrower's NFT by force\ntransaction(Uuid: UInt64, BorrowerAddress: Address) {\n\n    prepare(acct: AuthAccount) {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlace = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place resource\")\n\n        let ticketRef =  acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket resource\")\n\n        let returnNft <- lendingPlace.forcedRedeem(uuid: Uuid, lendticket: ticketRef)\n\n        let collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/jambbLaunchVouchersCollection)\n            ?? panic(\"Could not borrow owner's NFT collection reference\")\n\n        collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890705
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890777
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "BorrowerAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/vouchers-lend-money.json
+++ b/templates/Blocto/vouchers-lend-money.json
@@ -1,0 +1,70 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "f447164f9bb440b5eb1c6e47dc3488ae1a9feb13f27d53dbf45a4898cd4da6fd",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Vouchers Lend money"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Lend {LendAmount} FLOW tokens to {BorrowerAddress} borrower.",
+                    "zh-CN": "将 {LendAmount} FLOW 代币借给 {BorrowerAddress} 借方",
+                    "zh-TW": "將 {LendAmount} FLOW 代幣借給 {BorrowerAddress} 借方"
+                }
+            }
+        },
+        "cadence": "import NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the lender lend FLOW to borrower\ntransaction(BorrowerAddress: Address, LenderAddress: Address, Uuid: UInt64, LendAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n\n    let ticketRef:  &NFTLendingPlace.LenderTicket\n\n    prepare(acct: AuthAccount) {\n\n        // Init\n        if acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket) == nil {\n            let lendingTicket <- NFTLendingPlace.createLenderTicket()\n            acct.save(<-lendingTicket, to: /storage/NFTLendingPlaceCollectionLenderTicket)\n        }\n\n        self.ticketRef = acct.borrow<&NFTLendingPlace.LenderTicket>(from: /storage/NFTLendingPlaceCollectionLenderTicket)\n            ?? panic(\"Could not borrow lender's LenderTicket reference\")\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow lender's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: LendAmount) as! @FlowToken.Vault\n    }\n\n    execute {\n\n        let borrower = getAccount(BorrowerAddress)\n\n        let lendingPlaceRef = borrower.getCapability<&AnyResource{NFTLendingPlace.LendingPublic}>(/public/NFTLendingPlaceCollection)\n            .borrow()\n            ?? panic(\"Could not borrow borrower's NFT Lending Place recource\")\n\n        lendingPlaceRef.lendOut(uuid: Uuid, recipient: LenderAddress, lendAmount: <-self.temporaryVault, ticket:  self.ticketRef)\n    }\n}\n",
+        "dependencies": {
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890764
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890777
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "BorrowerAddress": {
+                "index": 0,
+                "type": "Address",
+                "messages": {}
+            },
+            "LenderAddress": {
+                "index": 1,
+                "type": "Address",
+                "messages": {}
+            },
+            "Uuid": {
+                "index": 2,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "LendAmount": {
+                "index": 3,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}

--- a/templates/Blocto/vouchers-repay.json
+++ b/templates/Blocto/vouchers-repay.json
@@ -1,0 +1,71 @@
+{
+    "f_type": "InteractionTemplate",
+    "f_version": "1.0.0",
+    "id": "a6f2e970f800a18490daceba5aeb4307fc5dabefa1d8a24f216be32dd9c4e372",
+    "data": {
+        "type": "InteractionTemplate",
+        "interface": "",
+        "messages": {
+            "title": {
+                "i18n": {
+                    "en-US": "Vouchers Repay"
+                }
+            },
+            "description": {
+                "i18n": {
+                    "en-US": "Redeem NFT {Uuid} with {RepayAmount} FLOW tokens.",
+                    "zh-CN": "用 {RepayAmount} FLOW 代币赎回 NFT {Uuid}",
+                    "zh-TW": "用 {RepayAmount} FLOW 代幣贖回 NFT {Uuid}"
+                }
+            }
+        },
+        "cadence": "import NonFungibleToken from 0xNON_FUNGIBLE_TOKEN_ADDRESS\nimport NFTLendingPlace from 0xMANTLEFI_NFTLENDINGPLACE\nimport FlowToken from 0xFLOW_TOKEN_ADDRESS\n\n// Let the borrower to repay FLOW\ntransaction(Uuid: UInt64, RepayAmount: UFix64) {\n\n    let temporaryVault: @FlowToken.Vault\n    let collectionRef: &NonFungibleToken.Collection\n    let landingPlaceRef: &NFTLendingPlace.LendingCollection\n\n    prepare(acct: AuthAccount) {\n\n        let vaultRef = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n            ?? panic(\"Could not borrow borrower's vault reference\")\n\n        self.temporaryVault <- vaultRef.withdraw(amount: RepayAmount) as! @FlowToken.Vault\n\n        self.collectionRef = acct.borrow<&NonFungibleToken.Collection>(from: /storage/jambbLaunchVouchersCollection)\n            ?? panic(\"Could not borrow borrower's NFT collection reference\")\n\n        self.landingPlaceRef =  acct.borrow<&NFTLendingPlace.LendingCollection>(from: /storage/NFTLendingPlaceCollection)\n            ?? panic(\"Could not borrow borrower's LenderTicket reference\")\n    }\n\n    execute {\n        let returnNft <- self.landingPlaceRef.repay(uuid: Uuid, repayAmount: <-self.temporaryVault)\n\n        self.collectionRef.deposit(token: <-returnNft)\n    }\n}\n",
+        "dependencies": {
+            "0xNON_FUNGIBLE_TOKEN_ADDRESS": {
+                "NonFungibleToken": {
+                    "testnet": {
+                        "address": "0x631e88ae7f1d7c20",
+                        "contract": "NonFungibleToken",
+                        "fq_address": "A.0x631e88ae7f1d7c20.NonFungibleToken",
+                        "pin": "83c9e3d61d3b5ebf24356a9f17b5b57b12d6d56547abc73e05f820a0ae7d9cf5",
+                        "pin_block_height": 138890777
+                    }
+                }
+            },
+            "0xMANTLEFI_NFTLENDINGPLACE": {
+                "NFTLendingPlace": {
+                    "testnet": {
+                        "address": "0x615a6bf3445b9c61",
+                        "contract": "NFTLendingPlace",
+                        "fq_address": "A.0x615a6bf3445b9c61.NFTLendingPlace",
+                        "pin": "7723617b4999f66ce1942ee3847d899b74dca4b43ff6f7ce75f32c7d8b5b43a6",
+                        "pin_block_height": 138890830
+                    }
+                }
+            },
+            "0xFLOW_TOKEN_ADDRESS": {
+                "FlowToken": {
+                    "testnet": {
+                        "address": "0x7e60df042a9c0868",
+                        "contract": "FlowToken",
+                        "fq_address": "A.0x7e60df042a9c0868.FlowToken",
+                        "pin": "0326c320322c4e8dde768ba2975c384184fb7e41765c2c87e79a2040bfc71be8",
+                        "pin_block_height": 138890846
+                    }
+                }
+            }
+        },
+        "arguments": {
+            "Uuid": {
+                "index": 0,
+                "type": "UInt64",
+                "messages": {}
+            },
+            "RepayAmount": {
+                "index": 1,
+                "type": "UFix64",
+                "messages": {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
Temporarily exposes Blocto's migrated Flow transaction templates (from https://github.com/blocto/flow-transactions/issues/59) through Flowser FLIX API. 

These transactions are built to work for testnet only, but this should be sufficient for Flowser use-case, since we don't need network-specific dependency info either way.